### PR TITLE
Add Instagram-style stories, reels, and privacy controls

### DIFF
--- a/backend/controllers/reel.controller.js
+++ b/backend/controllers/reel.controller.js
@@ -1,0 +1,127 @@
+import cloudinary from "../utils/cloudinary.js";
+import { Reel } from "../models/reel.model.js";
+import { User } from "../models/user.model.js";
+
+const canViewerSeeUser = (userDoc, viewerId) => {
+    if(!userDoc) return false;
+    if(userDoc.accountType === 'public') return true;
+    if(userDoc._id.equals(viewerId)) return true;
+    return userDoc.followers.some(followerId => followerId.equals(viewerId));
+}
+
+export const createReel = async (req, res) => {
+    try {
+        const { caption } = req.body;
+        const video = req.file;
+        const authorId = req.id;
+
+        if(!video){
+            return res.status(400).json({ success:false, message:'Video is required to create a reel' });
+        }
+
+        const fileUri = `data:${video.mimetype};base64,${video.buffer.toString('base64')}`;
+        const uploadResponse = await cloudinary.uploader.upload(fileUri, { resource_type:'video' });
+
+        let reel = await Reel.create({
+            caption,
+            videoUrl: uploadResponse.secure_url,
+            author: authorId
+        });
+
+        reel = await reel.populate({ path: 'author', select: 'username profilePicture accountType followers' });
+
+        return res.status(201).json({ success:true, reel, message:'Reel shared' });
+    } catch (error) {
+        console.log(error);
+        return res.status(500).json({ success:false, message:'Unable to create reel' });
+    }
+};
+
+export const getReels = async (req, res) => {
+    try {
+        const viewerId = req.id;
+        const viewer = await User.findById(viewerId).select('following');
+        const followings = viewer?.following?.map(id => id.toString()) || [];
+        const candidateIds = [...new Set([viewerId, ...followings])];
+
+        const reels = await Reel.find({ author: { $in: candidateIds } }).sort({ createdAt: -1 }).populate({
+            path: 'author',
+            select: 'username profilePicture accountType followers'
+        });
+
+        const visibleReels = reels.filter(reel => canViewerSeeUser(reel.author, viewerId));
+
+        return res.status(200).json({ success:true, reels: visibleReels });
+    } catch (error) {
+        console.log(error);
+        return res.status(500).json({ success:false, message:'Unable to fetch reels' });
+    }
+};
+
+export const likeReel = async (req, res) => {
+    try {
+        const reelId = req.params.id;
+        const viewerId = req.id;
+
+        const reel = await Reel.findById(reelId).populate({ path:'author', select:'accountType followers' });
+        if(!reel){
+            return res.status(404).json({ success:false, message:'Reel not found' });
+        }
+
+        if(!canViewerSeeUser(reel.author, viewerId)){
+            return res.status(403).json({ success:false, message:'You are not allowed to interact with this reel' });
+        }
+
+        if(!reel.likes.some(id => id.equals(viewerId))){
+            reel.likes.push(viewerId);
+            await reel.save();
+        }
+
+        return res.status(200).json({ success:true, message:'Reel liked', reelId });
+    } catch (error) {
+        console.log(error);
+        return res.status(500).json({ success:false, message:'Unable to like reel' });
+    }
+};
+
+export const unlikeReel = async (req, res) => {
+    try {
+        const reelId = req.params.id;
+        const viewerId = req.id;
+
+        const reel = await Reel.findById(reelId);
+        if(!reel){
+            return res.status(404).json({ success:false, message:'Reel not found' });
+        }
+
+        reel.likes = reel.likes.filter(id => !id.equals(viewerId));
+        await reel.save();
+
+        return res.status(200).json({ success:true, message:'Reel unliked', reelId });
+    } catch (error) {
+        console.log(error);
+        return res.status(500).json({ success:false, message:'Unable to unlike reel' });
+    }
+};
+
+export const recordReelView = async (req, res) => {
+    try {
+        const reelId = req.params.id;
+        const viewerId = req.id;
+
+        const reel = await Reel.findById(reelId);
+        if(!reel){
+            return res.status(404).json({ success:false, message:'Reel not found' });
+        }
+
+        if(!reel.views.some(id => id.equals(viewerId))){
+            reel.views.push(viewerId);
+            await reel.save();
+        }
+
+        return res.status(200).json({ success:true, reelId });
+    } catch (error) {
+        console.log(error);
+        return res.status(500).json({ success:false, message:'Unable to record reel view' });
+    }
+};

--- a/backend/controllers/story.controller.js
+++ b/backend/controllers/story.controller.js
@@ -1,0 +1,121 @@
+import sharp from "sharp";
+import cloudinary from "../utils/cloudinary.js";
+import { Story } from "../models/story.model.js";
+import { User } from "../models/user.model.js";
+
+const isImage = (mimetype = "") => mimetype.startsWith('image/');
+
+const canViewerSeeUser = (userDoc, viewerId) => {
+    if(!userDoc) return false;
+    if(userDoc.accountType === 'public') return true;
+    if(userDoc._id.equals(viewerId)) return true;
+    return userDoc.followers.some(followerId => followerId.equals(viewerId));
+}
+
+export const createStory = async (req, res) => {
+    try {
+        const media = req.file;
+        const ownerId = req.id;
+        const { caption } = req.body;
+
+        if(!media){
+            return res.status(400).json({ success:false, message:'Story media is required' });
+        }
+
+        let optimizedBuffer = media.buffer;
+        if(isImage(media.mimetype)){
+            optimizedBuffer = await sharp(media.buffer)
+                .resize({ width: 1080, height: 1920, fit: 'cover' })
+                .toFormat('jpeg', { quality: 80 })
+                .toBuffer();
+        }
+
+        const fileUri = `data:${media.mimetype};base64,${optimizedBuffer.toString('base64')}`;
+        const uploadResponse = await cloudinary.uploader.upload(fileUri, { resource_type: 'auto' });
+
+        let story = await Story.create({
+            owner: ownerId,
+            caption,
+            mediaUrl: uploadResponse.secure_url,
+            mediaType: isImage(media.mimetype) ? 'image' : 'video'
+        });
+
+        story = await story.populate({ path: 'owner', select: 'username profilePicture accountType followers' });
+
+        return res.status(201).json({ success:true, story });
+    } catch (error) {
+        console.log(error);
+        return res.status(500).json({ success:false, message:'Unable to create story' });
+    }
+};
+
+export const getStoryFeed = async (req, res) => {
+    try {
+        const viewerId = req.id;
+        const viewer = await User.findById(viewerId).select('following');
+        const followings = viewer?.following?.map(id => id.toString()) || [];
+        const candidateIds = [...new Set([viewerId, ...followings])];
+
+        const activeStories = await Story.find({
+            owner: { $in: candidateIds },
+            expiresAt: { $gt: new Date() }
+        }).sort({ createdAt: -1 }).populate({ path: 'owner', select: 'username profilePicture accountType followers' });
+
+        const visibleStories = activeStories.filter(story => canViewerSeeUser(story.owner, viewerId));
+        const myStories = visibleStories.filter(story => story.owner._id.equals(viewerId));
+        const feedStories = visibleStories.filter(story => !story.owner._id.equals(viewerId));
+
+        return res.status(200).json({ success:true, myStories, feedStories });
+    } catch (error) {
+        console.log(error);
+        return res.status(500).json({ success:false, message:'Unable to fetch stories' });
+    }
+};
+
+export const getUserStories = async (req, res) => {
+    try {
+        const viewerId = req.id;
+        const { id: userId } = req.params;
+
+        const user = await User.findById(userId).select('accountType followers');
+        if(!user){
+            return res.status(404).json({ success:false, message:'User not found' });
+        }
+
+        if(!canViewerSeeUser(user, viewerId)){
+            return res.status(403).json({ success:false, message:'This account is private' });
+        }
+
+        const stories = await Story.find({
+            owner: userId,
+            expiresAt: { $gt: new Date() }
+        }).sort({ createdAt: -1 }).populate({ path: 'owner', select: 'username profilePicture accountType followers' });
+
+        return res.status(200).json({ success:true, stories });
+    } catch (error) {
+        console.log(error);
+        return res.status(500).json({ success:false, message:'Unable to fetch stories' });
+    }
+};
+
+export const markStoryViewed = async (req, res) => {
+    try {
+        const storyId = req.params.id;
+        const viewerId = req.id;
+
+        const story = await Story.findById(storyId);
+        if(!story){
+            return res.status(404).json({ success:false, message:'Story not found' });
+        }
+
+        if(!story.viewers.some(id => id.equals(viewerId))){
+            story.viewers.push(viewerId);
+            await story.save();
+        }
+
+        return res.status(200).json({ success:true });
+    } catch (error) {
+        console.log(error);
+        return res.status(500).json({ success:false, message:'Unable to update story view' });
+    }
+};

--- a/backend/controllers/user.controller.js
+++ b/backend/controllers/user.controller.js
@@ -4,9 +4,17 @@ import jwt from "jsonwebtoken";
 import getDataUri from "../utils/datauri.js";
 import cloudinary from "../utils/cloudinary.js";
 import { Post } from "../models/post.model.js";
+import mongoose from "mongoose";
+const sanitizeUserForClient = (userDoc) => {
+    if(!userDoc) return null;
+    const user = userDoc.toObject({ getters: true });
+    delete user.password;
+    return user;
+};
+
 export const register = async (req, res) => {
     try {
-        const { username, email, password } = req.body;
+        const { username, email, password, accountType } = req.body;
         if (!username || !email || !password) {
             return res.status(401).json({
                 message: "Something is missing, please check!",
@@ -24,7 +32,8 @@ export const register = async (req, res) => {
         await User.create({
             username,
             email,
-            password: hashedPassword
+            password: hashedPassword,
+            accountType: accountType === 'private' ? 'private' : 'public'
         });
         return res.status(201).json({
             message: "Account created successfully.",
@@ -70,20 +79,25 @@ export const login = async (req, res) => {
                 return null;
             })
         )
-        user = {
+        const sanitizedUser = {
             _id: user._id,
             username: user.username,
             email: user.email,
             profilePicture: user.profilePicture,
             bio: user.bio,
+            gender: user.gender,
+            accountType: user.accountType,
             followers: user.followers,
             following: user.following,
-            posts: populatedPosts
-        }
+            followRequests: user.followRequests,
+            sentFollowRequests: user.sentFollowRequests,
+            posts: populatedPosts.filter(Boolean),
+            bookmarks: user.bookmarks
+        };
         return res.cookie('token', token, { httpOnly: true, sameSite: 'strict', maxAge: 1 * 24 * 60 * 60 * 1000 }).json({
             message: `Welcome back ${user.username}`,
             success: true,
-            user
+            user: sanitizedUser
         });
 
     } catch (error) {
@@ -103,9 +117,44 @@ export const logout = async (_, res) => {
 export const getProfile = async (req, res) => {
     try {
         const userId = req.params.id;
-        let user = await User.findById(userId).populate({path:'posts', createdAt:-1}).populate('bookmarks');
+        const viewerId = req.id;
+
+        let user = await User.findById(userId)
+            .select('-password')
+            .populate({path:'posts', options:{ sort:{ createdAt:-1 }}})
+            .populate('bookmarks');
+
+        if(!user){
+            return res.status(404).json({ success:false, message:'User not found' });
+        }
+
+        const isOwner = user._id.equals(viewerId);
+        const isFollowing = user.followers.some(followerId => followerId.equals(viewerId));
+        const hasPendingRequest = user.followRequests.some(requestId => requestId.equals(viewerId));
+        const canViewFullProfile = user.accountType === 'public' || isOwner || isFollowing;
+
+        const sanitizedUser = sanitizeUserForClient(user);
+        if(!isOwner){
+            sanitizedUser.bookmarks = [];
+            delete sanitizedUser.followRequests;
+            delete sanitizedUser.sentFollowRequests;
+        }
+        if(!canViewFullProfile){
+            sanitizedUser.posts = [];
+            sanitizedUser.bookmarks = [];
+        }
+        sanitizedUser.bookmarks = sanitizedUser.bookmarks || [];
+
         return res.status(200).json({
-            user,
+            user: sanitizedUser,
+            meta: {
+                canViewFullProfile,
+                isOwner,
+                isFollowing,
+                hasPendingRequest,
+                isPrivate: user.accountType === 'private',
+                totalPendingRequests: user.followRequests.length
+            },
             success: true
         });
     } catch (error) {
@@ -116,7 +165,7 @@ export const getProfile = async (req, res) => {
 export const editProfile = async (req, res) => {
     try {
         const userId = req.id;
-        const { bio, gender } = req.body;
+        const { bio, gender, accountType } = req.body;
         const profilePicture = req.file;
         let cloudResponse;
 
@@ -132,9 +181,27 @@ export const editProfile = async (req, res) => {
                 success: false
             });
         };
-        if (bio) user.bio = bio;
+        if (bio !== undefined) user.bio = bio;
         if (gender) user.gender = gender;
         if (profilePicture) user.profilePicture = cloudResponse.secure_url;
+        if(accountType && ['public','private'].includes(accountType)){
+            const previousType = user.accountType;
+            user.accountType = accountType;
+            if(previousType === 'private' && accountType === 'public'){
+                // auto approve pending requests when switching to public
+                const pendingFollowerIds = user.followRequests.map(id => id.toString());
+                if(pendingFollowerIds.length){
+                    await User.updateMany(
+                        { _id: { $in: pendingFollowerIds } },
+                        { $addToSet: { following: user._id }, $pull: { sentFollowRequests: user._id } }
+                    );
+                    const combinedFollowers = [...user.followers, ...user.followRequests];
+                    const uniqueFollowerIds = [...new Set(combinedFollowers.map(id => id.toString()))];
+                    user.followers = uniqueFollowerIds.map(id => new mongoose.Types.ObjectId(id));
+                    user.followRequests = [];
+                }
+            }
+        }
 
         await user.save();
 
@@ -185,23 +252,105 @@ export const followOrUnfollow = async (req, res) => {
             });
         }
         // mai check krunga ki follow krna hai ya unfollow
-        const isFollowing = user.following.includes(jiskoFollowKrunga);
+        const isFollowing = user.following.some(id => id.equals(jiskoFollowKrunga));
+        const hasPendingRequest = targetUser.followRequests.some(id => id.equals(followKrneWala));
+
         if (isFollowing) {
-            // unfollow logic ayega
             await Promise.all([
                 User.updateOne({ _id: followKrneWala }, { $pull: { following: jiskoFollowKrunga } }),
-                User.updateOne({ _id: jiskoFollowKrunga }, { $pull: { followers: followKrneWala } }),
-            ])
-            return res.status(200).json({ message: 'Unfollowed successfully', success: true });
-        } else {
-            // follow logic ayega
-            await Promise.all([
-                User.updateOne({ _id: followKrneWala }, { $push: { following: jiskoFollowKrunga } }),
-                User.updateOne({ _id: jiskoFollowKrunga }, { $push: { followers: followKrneWala } }),
-            ])
-            return res.status(200).json({ message: 'followed successfully', success: true });
+                User.updateOne({ _id: jiskoFollowKrunga }, { $pull: { followers: followKrneWala } })
+            ]);
+            return res.status(200).json({ message: 'Unfollowed successfully', success: true, status:'unfollowed' });
         }
+
+        if(targetUser.accountType === 'private'){
+            if(hasPendingRequest){
+                await Promise.all([
+                    User.updateOne({ _id: followKrneWala }, { $pull: { sentFollowRequests: jiskoFollowKrunga } }),
+                    User.updateOne({ _id: jiskoFollowKrunga }, { $pull: { followRequests: followKrneWala } })
+                ]);
+                return res.status(200).json({ message:'Follow request cancelled', success:true, status:'request_cancelled' });
+            }
+
+            await Promise.all([
+                User.updateOne({ _id: followKrneWala }, { $addToSet: { sentFollowRequests: jiskoFollowKrunga } }),
+                User.updateOne({ _id: jiskoFollowKrunga }, { $addToSet: { followRequests: followKrneWala } })
+            ]);
+
+            return res.status(200).json({ message:'Follow request sent', success:true, status:'requested' });
+        }
+
+        await Promise.all([
+            User.updateOne({ _id: followKrneWala }, { $addToSet: { following: jiskoFollowKrunga }, $pull: { sentFollowRequests: jiskoFollowKrunga } }),
+            User.updateOne({ _id: jiskoFollowKrunga }, { $addToSet: { followers: followKrneWala }, $pull: { followRequests: followKrneWala } })
+        ]);
+        return res.status(200).json({ message: 'followed successfully', success: true, status:'followed' });
     } catch (error) {
         console.log(error);
     }
 }
+
+export const getFollowRequests = async (req, res) => {
+    try {
+        const userId = req.id;
+        const user = await User.findById(userId)
+            .select('followRequests')
+            .populate({ path:'followRequests', select:'username profilePicture bio accountType' });
+
+        if(!user){
+            return res.status(404).json({ success:false, message:'User not found' });
+        }
+
+        return res.status(200).json({ success:true, requests:user.followRequests });
+    } catch (error) {
+        console.log(error);
+    }
+};
+
+export const respondToFollowRequest = async (req, res) => {
+    try {
+        const userId = req.id;
+        const { requesterId, action } = req.body;
+
+        if(!requesterId || !['accept','decline'].includes(action)){
+            return res.status(400).json({ success:false, message:'Invalid request' });
+        }
+
+        const [user, requester] = await Promise.all([
+            User.findById(userId),
+            User.findById(requesterId)
+        ]);
+
+        if(!user || !requester){
+            return res.status(404).json({ success:false, message:'User not found' });
+        }
+
+        const hasRequest = user.followRequests.some(id => id.equals(requesterId));
+        if(!hasRequest){
+            return res.status(400).json({ success:false, message:'Follow request not found' });
+        }
+
+        let message = 'Request declined';
+
+        if(action === 'accept'){
+            await Promise.all([
+                User.updateOne({ _id: userId }, { $addToSet: { followers: requesterId }, $pull: { followRequests: requesterId } }),
+                User.updateOne({ _id: requesterId }, { $addToSet: { following: userId }, $pull: { sentFollowRequests: userId } })
+            ]);
+            message = 'Request accepted';
+        }else{
+            await Promise.all([
+                User.updateOne({ _id: userId }, { $pull: { followRequests: requesterId } }),
+                User.updateOne({ _id: requesterId }, { $pull: { sentFollowRequests: userId } })
+            ]);
+        }
+
+        const updatedUser = await User.findById(userId)
+            .select('-password')
+            .populate({ path:'followRequests', select:'username profilePicture bio accountType' });
+
+        return res.status(200).json({ success:true, message, user: sanitizeUserForClient(updatedUser), requests: updatedUser.followRequests });
+    } catch (error) {
+        console.log(error);
+    }
+};

--- a/backend/index.js
+++ b/backend/index.js
@@ -6,6 +6,8 @@ import connectDB from "./utils/db.js";
 import userRoute from "./routes/user.route.js";
 import postRoute from "./routes/post.route.js";
 import messageRoute from "./routes/message.route.js";
+import storyRoute from "./routes/story.route.js";
+import reelRoute from "./routes/reel.route.js";
 import { app, server } from "./socket/socket.js";
 import path from "path";
  
@@ -30,6 +32,8 @@ app.use(cors(corsOptions));
 app.use("/api/v1/user", userRoute);
 app.use("/api/v1/post", postRoute);
 app.use("/api/v1/message", messageRoute);
+app.use("/api/v1/story", storyRoute);
+app.use("/api/v1/reel", reelRoute);
 
 
 app.use(express.static(path.join(__dirname, "/frontend/dist")));

--- a/backend/models/reel.model.js
+++ b/backend/models/reel.model.js
@@ -1,0 +1,12 @@
+import mongoose from "mongoose";
+
+const reelSchema = new mongoose.Schema({
+    caption:{type:String, default:''},
+    videoUrl:{type:String, required:true},
+    coverImage:{type:String, default:''},
+    author:{type:mongoose.Schema.Types.ObjectId, ref:'User', required:true},
+    likes:[{type:mongoose.Schema.Types.ObjectId, ref:'User'}],
+    views:[{type:mongoose.Schema.Types.ObjectId, ref:'User'}],
+},{timestamps:true});
+
+export const Reel = mongoose.model('Reel', reelSchema);

--- a/backend/models/story.model.js
+++ b/backend/models/story.model.js
@@ -1,0 +1,14 @@
+import mongoose from "mongoose";
+
+const storySchema = new mongoose.Schema({
+    owner:{type:mongoose.Schema.Types.ObjectId, ref:'User', required:true},
+    mediaUrl:{type:String, required:true},
+    mediaType:{type:String, enum:['image','video'], default:'image'},
+    caption:{type:String, default:''},
+    viewers:[{type:mongoose.Schema.Types.ObjectId, ref:'User'}],
+    expiresAt:{type:Date, default:() => new Date(Date.now() + 24*60*60*1000)}
+},{timestamps:true});
+
+storySchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 });
+
+export const Story = mongoose.model('Story', storySchema);

--- a/backend/models/user.model.js
+++ b/backend/models/user.model.js
@@ -7,8 +7,11 @@ const userSchema = new mongoose.Schema({
     profilePicture:{type:String,default:''},
     bio:{type:String, default:''},
     gender:{type:String,enum:['male','female']},
+    accountType:{type:String, enum:['public','private'], default:'public'},
     followers:[{type:mongoose.Schema.Types.ObjectId, ref:'User'}],
     following:[{type:mongoose.Schema.Types.ObjectId, ref:'User'}],
+    followRequests:[{type:mongoose.Schema.Types.ObjectId, ref:'User'}],
+    sentFollowRequests:[{type:mongoose.Schema.Types.ObjectId, ref:'User'}],
     posts:[{type:mongoose.Schema.Types.ObjectId, ref:'Post'}],
     bookmarks:[{type:mongoose.Schema.Types.ObjectId, ref:'Post'}]
 },{timestamps:true});

--- a/backend/routes/reel.route.js
+++ b/backend/routes/reel.route.js
@@ -1,0 +1,21 @@
+import express from "express";
+import isAuthenticated from "../middlewares/isAuthenticated.js";
+import upload from "../middlewares/multer.js";
+import { createReel, getReels, likeReel, unlikeReel, recordReelView } from "../controllers/reel.controller.js";
+
+const router = express.Router();
+
+router.route('/')
+    .post(isAuthenticated, upload.single('video'), createReel)
+    .get(isAuthenticated, getReels);
+
+router.route('/:id/like')
+    .post(isAuthenticated, likeReel);
+
+router.route('/:id/unlike')
+    .post(isAuthenticated, unlikeReel);
+
+router.route('/:id/view')
+    .post(isAuthenticated, recordReelView);
+
+export default router;

--- a/backend/routes/story.route.js
+++ b/backend/routes/story.route.js
@@ -1,0 +1,20 @@
+import express from "express";
+import isAuthenticated from "../middlewares/isAuthenticated.js";
+import upload from "../middlewares/multer.js";
+import { createStory, getStoryFeed, getUserStories, markStoryViewed } from "../controllers/story.controller.js";
+
+const router = express.Router();
+
+router.route('/')
+    .post(isAuthenticated, upload.single('media'), createStory);
+
+router.route('/feed')
+    .get(isAuthenticated, getStoryFeed);
+
+router.route('/:id')
+    .get(isAuthenticated, getUserStories);
+
+router.route('/:id/view')
+    .post(isAuthenticated, markStoryViewed);
+
+export default router;

--- a/backend/routes/user.route.js
+++ b/backend/routes/user.route.js
@@ -1,5 +1,5 @@
 import express from "express";
-import { editProfile, followOrUnfollow, getProfile, getSuggestedUsers, login, logout, register } from "../controllers/user.controller.js";
+import { editProfile, followOrUnfollow, getProfile, getSuggestedUsers, login, logout, register, getFollowRequests, respondToFollowRequest } from "../controllers/user.controller.js";
 import isAuthenticated from "../middlewares/isAuthenticated.js";
 import upload from "../middlewares/multer.js";
 
@@ -12,5 +12,7 @@ router.route('/:id/profile').get(isAuthenticated, getProfile);
 router.route('/profile/edit').post(isAuthenticated, upload.single('profilePhoto'), editProfile);
 router.route('/suggested').get(isAuthenticated, getSuggestedUsers);
 router.route('/followorunfollow/:id').post(isAuthenticated, followOrUnfollow);
+router.route('/follow-requests').get(isAuthenticated, getFollowRequests);
+router.route('/follow-requests/respond').post(isAuthenticated, respondToFollowRequest);
 
 export default router;

--- a/frontend/src/components/EditProfile.jsx
+++ b/frontend/src/components/EditProfile.jsx
@@ -17,7 +17,8 @@ const EditProfile = () => {
     const [input, setInput] = useState({
         profilePhoto: user?.profilePicture,
         bio: user?.bio,
-        gender: user?.gender
+        gender: user?.gender,
+        accountType: user?.accountType || 'public'
     });
     const navigate = useNavigate();
     const dispatch = useDispatch();
@@ -35,8 +36,9 @@ const EditProfile = () => {
     const editProfileHandler = async () => {
         console.log(input);
         const formData = new FormData();
-        formData.append("bio", input.bio);
-        formData.append("gender", input.gender);
+        formData.append("bio", input.bio ?? "");
+        formData.append("gender", input.gender ?? "");
+        formData.append("accountType", input.accountType);
         if(input.profilePhoto){
             formData.append("profilePhoto", input.profilePhoto);
         }
@@ -53,7 +55,8 @@ const EditProfile = () => {
                     ...user,
                     bio:res.data.user?.bio,
                     profilePicture:res.data.user?.profilePicture,
-                    gender:res.data.user.gender
+                    gender:res.data.user.gender,
+                    accountType:res.data.user?.accountType
                 };
                 dispatch(setAuthUser(updatedUserData));
                 navigate(`/profile/${user?._id}`);
@@ -99,6 +102,20 @@ const EditProfile = () => {
                             <SelectGroup>
                                 <SelectItem value="male">Male</SelectItem>
                                 <SelectItem value="female">Female</SelectItem>
+                            </SelectGroup>
+                        </SelectContent>
+                    </Select>
+                </div>
+                <div>
+                    <h1 className='font-bold mb-2'>Account privacy</h1>
+                    <Select value={input.accountType} onValueChange={(value) => setInput(prev => ({ ...prev, accountType: value }))}>
+                        <SelectTrigger className="w-full">
+                            <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                            <SelectGroup>
+                                <SelectItem value="public">Public</SelectItem>
+                                <SelectItem value="private">Private</SelectItem>
                             </SelectGroup>
                         </SelectContent>
                     </Select>

--- a/frontend/src/components/Feed.jsx
+++ b/frontend/src/components/Feed.jsx
@@ -1,9 +1,13 @@
 import React from 'react'
 import Posts from './Posts'
+import StoriesBar from './StoriesBar'
+import ReelsShelf from './ReelsShelf'
 
 const Feed = () => {
   return (
-    <div className='flex-1 my-8 flex flex-col items-center pl-[20%]'>
+    <div className='flex-1 my-8 flex flex-col gap-6 items-center pl-[20%] pr-6'>
+        <StoriesBar />
+        <ReelsShelf />
         <Posts/>
     </div>
   )

--- a/frontend/src/components/FollowRequests.jsx
+++ b/frontend/src/components/FollowRequests.jsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+import { Avatar, AvatarFallback, AvatarImage } from './ui/avatar';
+import { Button } from './ui/button';
+import useFollowRequests from '@/hooks/useFollowRequests';
+import { toast } from 'sonner';
+
+const FollowRequests = () => {
+    const { followRequests } = useSelector(store => store.auth);
+    const { respondToRequest } = useFollowRequests();
+
+    const handleRespond = async (requesterId, action) => {
+        try {
+            const res = await respondToRequest({ requesterId, action });
+            if(res?.success){
+                toast.success(res.message);
+            }
+        } catch (error) {
+            toast.error(error?.response?.data?.message || 'Unable to update request');
+        }
+    };
+
+    if(!followRequests?.length) return null;
+
+    return (
+        <div className='mt-8 bg-white border border-gray-200 rounded-2xl p-4 shadow-sm'>
+            <div className='flex items-center justify-between mb-4'>
+                <h2 className='font-semibold text-sm'>Follow requests</h2>
+                <span className='text-xs text-gray-500'>{followRequests.length}</span>
+            </div>
+            <div className='flex flex-col gap-4'>
+                {followRequests.map(request => (
+                    <div key={request._id} className='flex items-center justify-between gap-2'>
+                        <div className='flex items-center gap-3'>
+                            <Avatar className='h-10 w-10'>
+                                <AvatarImage src={request.profilePicture} />
+                                <AvatarFallback>RQ</AvatarFallback>
+                            </Avatar>
+                            <div className='flex flex-col'>
+                                <span className='text-sm font-semibold'>{request.username}</span>
+                                <span className='text-xs text-gray-500'>{request.bio || 'Wants to follow you'}</span>
+                            </div>
+                        </div>
+                        <div className='flex items-center gap-2'>
+                            <Button size='sm' onClick={() => handleRespond(request._id, 'accept')}>Confirm</Button>
+                            <Button size='sm' variant='outline' onClick={() => handleRespond(request._id, 'decline')}>Delete</Button>
+                        </div>
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+};
+
+export default FollowRequests;

--- a/frontend/src/components/Home.jsx
+++ b/frontend/src/components/Home.jsx
@@ -4,10 +4,14 @@ import { Outlet } from 'react-router-dom'
 import RightSidebar from './RightSidebar'
 import useGetAllPost from '@/hooks/useGetAllPost'
 import useGetSuggestedUsers from '@/hooks/useGetSuggestedUsers'
+import useStoryFeed from '@/hooks/useStoryFeed'
+import useReels from '@/hooks/useReels'
 
 const Home = () => {
     useGetAllPost();
     useGetSuggestedUsers();
+    useStoryFeed();
+    useReels();
     return (
         <div className='flex'>
             <div className='flex-grow'>

--- a/frontend/src/components/Profile.jsx
+++ b/frontend/src/components/Profile.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import { Avatar, AvatarFallback, AvatarImage } from './ui/avatar'
 import useGetUserProfile from '@/hooks/useGetUserProfile';
 import { Link, useParams } from 'react-router-dom';
@@ -6,23 +6,51 @@ import { useSelector } from 'react-redux';
 import { Button } from './ui/button';
 import { Badge } from './ui/badge';
 import { AtSign, Heart, MessageCircle } from 'lucide-react';
+import axios from 'axios';
+import { toast } from 'sonner';
 
 const Profile = () => {
   const params = useParams();
   const userId = params.id;
-  useGetUserProfile(userId);
+  const { refetch } = useGetUserProfile(userId);
   const [activeTab, setActiveTab] = useState('posts');
 
-  const { userProfile, user } = useSelector(store => store.auth);
+  useEffect(() => {
+    setActiveTab('posts');
+  }, [userId]);
+
+  const { userProfile, user, userProfileMeta } = useSelector(store => store.auth);
 
   const isLoggedInUserProfile = user?._id === userProfile?._id;
-  const isFollowing = false;
+  const isFollowing = userProfileMeta?.isFollowing;
+  const hasPendingRequest = userProfileMeta?.hasPendingRequest;
+  const canViewProfile = userProfileMeta?.canViewFullProfile || isLoggedInUserProfile;
 
   const handleTabChange = (tab) => {
     setActiveTab(tab);
   }
 
   const displayedPost = activeTab === 'posts' ? userProfile?.posts : userProfile?.bookmarks;
+
+  const handleFollowAction = async () => {
+    try {
+      const res = await axios.post(`https://let-s-talk-lq7h.onrender.com/api/v1/user/followorunfollow/${userId}`, {}, { withCredentials: true });
+      if(res.data.success){
+        toast.success(res.data.message);
+        await refetch();
+      }
+    } catch (error) {
+      console.log(error);
+      toast.error(error?.response?.data?.message || 'Something went wrong');
+    }
+  };
+
+  const followButtonLabel = useMemo(() => {
+    if(isLoggedInUserProfile) return null;
+    if(isFollowing) return 'Unfollow';
+    if(hasPendingRequest) return 'Requested';
+    return 'Follow';
+  }, [isFollowing, hasPendingRequest, isLoggedInUserProfile]);
 
   return (
     <div className='flex max-w-5xl justify-center mx-auto pl-10'>
@@ -46,14 +74,23 @@ const Profile = () => {
                       <Button variant='secondary' className='hover:bg-gray-200 h-8'>Ad tools</Button>
                     </>
                   ) : (
-                    isFollowing ? (
-                      <>
-                        <Button variant='secondary' className='h-8'>Unfollow</Button>
+                    <>
+                      {
+                        followButtonLabel && (
+                          <Button
+                            disabled={followButtonLabel === 'Requested'}
+                            onClick={followButtonLabel === 'Requested' ? undefined : handleFollowAction}
+                            className={`h-8 ${followButtonLabel === 'Follow' ? 'bg-[#0095F6] hover:bg-[#3192d2]' : ''}`}
+                            variant={followButtonLabel === 'Unfollow' ? 'secondary' : 'default'}
+                          >
+                            {followButtonLabel}
+                          </Button>
+                        )
+                      }
+                      {isFollowing && (
                         <Button variant='secondary' className='h-8'>Message</Button>
-                      </>
-                    ) : (
-                      <Button className='bg-[#0095F6] hover:bg-[#3192d2] h-8'>Follow</Button>
-                    )
+                      )}
+                    </>
                   )
                 }
               </div>
@@ -64,7 +101,12 @@ const Profile = () => {
               </div>
               <div className='flex flex-col gap-1'>
                 <span className='font-semibold'>{userProfile?.bio || 'bio here...'}</span>
-                <Badge className='w-fit' variant='secondary'><AtSign /> <span className='pl-1'>{userProfile?.username}</span> </Badge>
+                <div className='flex items-center gap-2'>
+                  <Badge className='w-fit' variant='secondary'><AtSign /> <span className='pl-1'>{userProfile?.username}</span> </Badge>
+                  <Badge variant={userProfile?.accountType === 'private' ? 'destructive' : 'outline'}>
+                    {userProfile?.accountType === 'private' ? 'Private account' : 'Public account'}
+                  </Badge>
+                </div>
               </div>
             </div>
           </section>
@@ -74,35 +116,46 @@ const Profile = () => {
             <span className={`py-3 cursor-pointer ${activeTab === 'posts' ? 'font-bold' : ''}`} onClick={() => handleTabChange('posts')}>
               POSTS
             </span>
-            <span className={`py-3 cursor-pointer ${activeTab === 'saved' ? 'font-bold' : ''}`} onClick={() => handleTabChange('saved')}>
-              SAVED
-            </span>
-            <span className='py-3 cursor-pointer'>REELS</span>
-            <span className='py-3 cursor-pointer'>TAGS</span>
+            {isLoggedInUserProfile && (
+              <span className={`py-3 cursor-pointer ${activeTab === 'saved' ? 'font-bold' : ''}`} onClick={() => handleTabChange('saved')}>
+                SAVED
+              </span>
+            )}
+            <span className='py-3 cursor-pointer text-gray-400'>REELS</span>
+            <span className='py-3 cursor-pointer text-gray-400'>TAGS</span>
           </div>
-          <div className='grid grid-cols-3 gap-1'>
-            {
-              displayedPost?.map((post) => {
-                return (
-                  <div key={post?._id} className='relative group cursor-pointer'>
-                    <img src={post.image} alt='postimage' className='rounded-sm my-2 w-full aspect-square object-cover' />
-                    <div className='absolute inset-0 flex items-center justify-center bg-black bg-opacity-50 opacity-0 group-hover:opacity-100 transition-opacity duration-300'>
-                      <div className='flex items-center text-white space-x-4'>
-                        <button className='flex items-center gap-2 hover:text-gray-300'>
-                          <Heart />
-                          <span>{post?.likes.length}</span>
-                        </button>
-                        <button className='flex items-center gap-2 hover:text-gray-300'>
-                          <MessageCircle />
-                          <span>{post?.comments.length}</span>
-                        </button>
+          {
+            canViewProfile ? (
+              <div className='grid grid-cols-3 gap-1'>
+                {
+                  displayedPost?.map((post) => {
+                    return (
+                      <div key={post?._id} className='relative group cursor-pointer'>
+                        <img src={post.image} alt='postimage' className='rounded-sm my-2 w-full aspect-square object-cover' />
+                        <div className='absolute inset-0 flex items-center justify-center bg-black bg-opacity-50 opacity-0 group-hover:opacity-100 transition-opacity duration-300'>
+                          <div className='flex items-center text-white space-x-4'>
+                            <button className='flex items-center gap-2 hover:text-gray-300'>
+                              <Heart />
+                              <span>{post?.likes.length}</span>
+                            </button>
+                            <button className='flex items-center gap-2 hover:text-gray-300'>
+                              <MessageCircle />
+                              <span>{post?.comments.length}</span>
+                            </button>
+                          </div>
+                        </div>
                       </div>
-                    </div>
-                  </div>
-                )
-              })
-            }
-          </div>
+                    )
+                  })
+                }
+              </div>
+            ) : (
+              <div className='flex flex-col items-center gap-2 py-10 text-center text-sm text-gray-500'>
+                <p>This account is private.</p>
+                <p>Send a follow request to see their posts.</p>
+              </div>
+            )
+          }
         </div>
       </div>
     </div>

--- a/frontend/src/components/ReelCard.jsx
+++ b/frontend/src/components/ReelCard.jsx
@@ -1,0 +1,88 @@
+import React, { useState } from 'react';
+import { Avatar, AvatarFallback, AvatarImage } from './ui/avatar';
+import { Button } from './ui/button';
+import { Heart, Play } from 'lucide-react';
+import { useDispatch, useSelector } from 'react-redux';
+import axios from 'axios';
+import { toggleReelLike } from '@/redux/reelSlice';
+
+const ReelCard = ({ reel }) => {
+    const { user } = useSelector(store => store.auth);
+    const dispatch = useDispatch();
+    const [viewed, setViewed] = useState(reel.views?.includes(user?._id));
+    const [likeLoading, setLikeLoading] = useState(false);
+    const isLiked = reel.likes?.includes(user?._id);
+
+    const toggleLike = async () => {
+        if(!user?._id) return;
+        try {
+            setLikeLoading(true);
+            if(isLiked){
+                await axios.post(`https://let-s-talk-lq7h.onrender.com/api/v1/reel/${reel._id}/unlike`, {}, { withCredentials: true });
+                dispatch(toggleReelLike({ reelId: reel._id, userId: user._id, liked: false }));
+            }else{
+                await axios.post(`https://let-s-talk-lq7h.onrender.com/api/v1/reel/${reel._id}/like`, {}, { withCredentials: true });
+                dispatch(toggleReelLike({ reelId: reel._id, userId: user._id, liked: true }));
+            }
+        } catch (error) {
+            console.log(error);
+        } finally {
+            setLikeLoading(false);
+        }
+    };
+
+    const markView = async () => {
+        if(viewed || !user?._id) return;
+        try {
+            setViewed(true);
+            await axios.post(`https://let-s-talk-lq7h.onrender.com/api/v1/reel/${reel._id}/view`, {}, { withCredentials: true });
+        } catch (error) {
+            console.log(error);
+        }
+    };
+
+    return (
+        <div className='bg-white border border-gray-200 rounded-2xl overflow-hidden shadow-sm'>
+            <div className='flex items-center gap-3 px-4 py-3'>
+                <Avatar>
+                    <AvatarImage src={reel.author?.profilePicture} />
+                    <AvatarFallback>AU</AvatarFallback>
+                </Avatar>
+                <div className='flex flex-col'>
+                    <span className='text-sm font-semibold'>{reel.author?.username}</span>
+                    <span className='text-xs text-gray-500'>{new Date(reel.createdAt).toLocaleString()}</span>
+                </div>
+            </div>
+            <div className='relative bg-black'>
+                <video
+                    src={reel.videoUrl}
+                    controls
+                    playsInline
+                    className='w-full max-h-[480px] object-contain bg-black'
+                    onPlay={markView}
+                />
+                <div className='absolute bottom-3 left-3 flex items-center gap-2 text-white text-xs bg-black/40 px-2 py-1 rounded-full'>
+                    <Play size={14} />
+                    <span>{reel.views?.length || 0} views</span>
+                </div>
+            </div>
+            <div className='p-4 flex flex-col gap-3'>
+                <div className='flex items-center gap-3'>
+                    <Button variant={isLiked ? 'default' : 'outline'} size='sm' onClick={toggleLike} disabled={likeLoading}>
+                        <Heart className={`h-4 w-4 mr-2 ${isLiked ? 'fill-current' : ''}`} />
+                        {isLiked ? 'Liked' : 'Like'}
+                    </Button>
+                    <span className='text-xs text-gray-500'>{reel.likes?.length || 0} likes</span>
+                </div>
+                {reel.caption && (
+                    <p className='text-sm text-gray-700'>
+                        <span className='font-semibold mr-2'>{reel.author?.username}</span>
+                        {reel.caption}
+                    </p>
+                )}
+            </div>
+        </div>
+    );
+};
+
+export default ReelCard;

--- a/frontend/src/components/ReelComposer.jsx
+++ b/frontend/src/components/ReelComposer.jsx
@@ -1,0 +1,120 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { Dialog, DialogContent, DialogHeader } from './ui/dialog';
+import { Avatar, AvatarFallback, AvatarImage } from './ui/avatar';
+import { Textarea } from './ui/textarea';
+import { Button } from './ui/button';
+import { useDispatch, useSelector } from 'react-redux';
+import axios from 'axios';
+import { Loader2 } from 'lucide-react';
+import { toast } from 'sonner';
+import { addReel } from '@/redux/reelSlice';
+
+const ReelComposer = () => {
+    const { user } = useSelector(store => store.auth);
+    const dispatch = useDispatch();
+    const [open, setOpen] = useState(false);
+    const [caption, setCaption] = useState('');
+    const [videoPreview, setVideoPreview] = useState('');
+    const [videoFile, setVideoFile] = useState(null);
+    const [loading, setLoading] = useState(false);
+    const fileInputRef = useRef();
+
+    const handleFileChange = (event) => {
+        const file = event.target.files?.[0];
+        if(!file) return;
+        if(!file.type.startsWith('video/')){
+            toast.error('Please select a video file');
+            return;
+        }
+        setVideoFile(file);
+        setVideoPreview(URL.createObjectURL(file));
+    };
+
+    const reset = () => {
+        setCaption('');
+        setVideoPreview('');
+        setVideoFile(null);
+        setOpen(false);
+    };
+
+    const submitReel = async () => {
+        if(!videoFile){
+            toast.error('Please choose a video');
+            return;
+        }
+        const formData = new FormData();
+        formData.append('caption', caption);
+        formData.append('video', videoFile);
+        try {
+            setLoading(true);
+            const res = await axios.post('https://let-s-talk-lq7h.onrender.com/api/v1/reel', formData, {
+                headers: { 'Content-Type': 'multipart/form-data' },
+                withCredentials: true
+            });
+            if(res.data.success){
+                dispatch(addReel(res.data.reel));
+                toast.success(res.data.message || 'Reel shared');
+                reset();
+            }
+        } catch (error) {
+            console.log(error);
+            toast.error(error?.response?.data?.message || 'Unable to share reel');
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        if(videoPreview){
+            return () => URL.revokeObjectURL(videoPreview);
+        }
+    }, [videoPreview]);
+
+    return (
+        <>
+            <Button onClick={() => setOpen(true)} className='bg-black hover:bg-black/80 text-white'>Share reel</Button>
+            <Dialog open={open} onOpenChange={(value) => value ? setOpen(true) : reset()}>
+                <DialogContent onInteractOutside={reset} className='max-w-xl'>
+                    <DialogHeader className='text-center font-semibold'>Create reel</DialogHeader>
+                    <div className='flex items-center gap-3'>
+                        <Avatar>
+                            <AvatarImage src={user?.profilePicture} />
+                            <AvatarFallback>CN</AvatarFallback>
+                        </Avatar>
+                        <div className='flex flex-col'>
+                            <span className='text-sm font-semibold'>{user?.username}</span>
+                            <span className='text-xs text-gray-500'>Share immersive vertical videos</span>
+                        </div>
+                    </div>
+                    <Textarea
+                        value={caption}
+                        onChange={(e) => setCaption(e.target.value)}
+                        placeholder='Write a caption...'
+                        className='focus-visible:ring-transparent'
+                    />
+                    {
+                        videoPreview && (
+                            <video src={videoPreview} controls className='rounded-xl w-full max-h-80' />
+                        )
+                    }
+                    <input ref={fileInputRef} onChange={handleFileChange} type='file' accept='video/*' className='hidden' />
+                    <div className='flex gap-3 justify-end'>
+                        <Button variant='outline' onClick={() => fileInputRef.current?.click()}>Select video</Button>
+                        {
+                            loading ? (
+                                <Button disabled>
+                                    <Loader2 className='mr-2 h-4 w-4 animate-spin' />
+                                    Uploading
+                                </Button>
+                            ) : (
+                                <Button onClick={submitReel} disabled={!videoFile}>Share</Button>
+                            )
+                        }
+                    </div>
+                </DialogContent>
+            </Dialog>
+        </>
+    );
+};
+
+export default ReelComposer;

--- a/frontend/src/components/ReelsShelf.jsx
+++ b/frontend/src/components/ReelsShelf.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+import ReelComposer from './ReelComposer';
+import ReelCard from './ReelCard';
+
+const ReelsShelf = () => {
+    const { reels, isLoading } = useSelector(store => store.reel);
+
+    return (
+        <div className='w-full bg-white border border-gray-200 rounded-2xl p-4 shadow-sm flex flex-col gap-4'>
+            <div className='flex items-center justify-between'>
+                <div>
+                    <h2 className='font-semibold text-sm'>Reels</h2>
+                    <p className='text-xs text-gray-500'>Enjoy full-screen vertical videos from your network.</p>
+                </div>
+                <ReelComposer />
+            </div>
+            {
+                isLoading ? (
+                    <div className='text-center text-sm text-gray-500 py-10'>Loading reels...</div>
+                ) : reels.length === 0 ? (
+                    <div className='text-center text-sm text-gray-500 py-10'>No reels yet. Be the first to share!</div>
+                ) : (
+                    <div className='flex flex-col gap-6'>
+                        {reels.map(reel => <ReelCard key={reel._id} reel={reel} />)}
+                    </div>
+                )
+            }
+        </div>
+    );
+};
+
+export default ReelsShelf;

--- a/frontend/src/components/RightSidebar.jsx
+++ b/frontend/src/components/RightSidebar.jsx
@@ -3,6 +3,7 @@ import { Avatar, AvatarFallback, AvatarImage } from './ui/avatar'
 import { useSelector } from 'react-redux'
 import { Link } from 'react-router-dom';
 import SuggestedUsers from './SuggestedUsers';
+import FollowRequests from './FollowRequests';
 
 const RightSidebar = () => {
   const { user } = useSelector(store => store.auth);
@@ -21,6 +22,7 @@ const RightSidebar = () => {
         </div>
       </div>
       <SuggestedUsers/>
+      <FollowRequests />
     </div>
   )
 }

--- a/frontend/src/components/Signup.jsx
+++ b/frontend/src/components/Signup.jsx
@@ -11,7 +11,8 @@ const Signup = () => {
     const [input, setInput] = useState({
         username: "",
         email: "",
-        password: ""
+        password: "",
+        accountType: 'public'
     });
     const [loading, setLoading] = useState(false);
     const {user} = useSelector(store=>store.auth);
@@ -37,7 +38,8 @@ const Signup = () => {
                 setInput({
                     username: "",
                     email: "",
-                    password: ""
+                    password: "",
+                    accountType: 'public'
                 });
             }
         } catch (error) {
@@ -89,6 +91,18 @@ const Signup = () => {
                         onChange={changeEventHandler}
                         className="focus-visible:ring-transparent my-2"
                     />
+                </div>
+                <div>
+                    <span className='font-medium'>Account type</span>
+                    <select
+                        name="accountType"
+                        value={input.accountType}
+                        onChange={changeEventHandler}
+                        className='w-full border rounded-md py-2 px-3 text-sm outline-none'
+                    >
+                        <option value='public'>Public</option>
+                        <option value='private'>Private</option>
+                    </select>
                 </div>
                 {
                     loading ? (

--- a/frontend/src/components/StoriesBar.jsx
+++ b/frontend/src/components/StoriesBar.jsx
@@ -1,0 +1,91 @@
+import React, { useMemo, useState } from 'react';
+import { useSelector } from 'react-redux';
+import { Avatar, AvatarFallback, AvatarImage } from './ui/avatar';
+import StoryComposer from './StoryComposer';
+import StoryViewer from './StoryViewer';
+
+const StoryBubble = ({ story, label, onClick }) => {
+    return (
+        <button onClick={() => onClick(story)} className='flex flex-col items-center gap-2 focus:outline-none'>
+            <div className='p-[2px] bg-gradient-to-tr from-pink-500 via-red-500 to-yellow-500 rounded-full'>
+                <Avatar className='h-16 w-16 border-4 border-white'>
+                    <AvatarImage src={story?.owner?.profilePicture} alt={story?.owner?.username} />
+                    <AvatarFallback>ST</AvatarFallback>
+                </Avatar>
+            </div>
+            <span className='text-xs text-gray-600'>{label}</span>
+        </button>
+    );
+};
+
+const StoriesBar = () => {
+    const { myStories, stories, isLoading } = useSelector(store => store.story);
+    const { user } = useSelector(store => store.auth);
+    const [activeStory, setActiveStory] = useState(null);
+    const [viewerOpen, setViewerOpen] = useState(false);
+
+    const orderedStories = useMemo(() => {
+        return [...stories].sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
+    }, [stories]);
+
+    const openStory = (story) => {
+        if(!story) return;
+        setActiveStory(story);
+        setViewerOpen(true);
+    };
+
+    return (
+        <div className='w-full bg-white border border-gray-200 rounded-2xl p-4 shadow-sm'>
+            <div className='flex items-center justify-between mb-3 gap-3'>
+                <div>
+                    <h2 className='font-semibold text-sm'>Stories</h2>
+                    <p className='text-xs text-gray-500'>Share what you are up to for 24 hours.</p>
+                </div>
+                <div className='w-40'>
+                    <StoryComposer />
+                </div>
+            </div>
+            {
+                isLoading ? (
+                    <div className='text-sm text-gray-500 py-6 text-center'>Loading stories...</div>
+                ) : (
+                    <div className='flex gap-4 overflow-x-auto pb-2'>
+                        {
+                            myStories.length > 0 ? (
+                                myStories.map((story) => (
+                                    <StoryBubble
+                                        key={story._id}
+                                        story={story}
+                                        label='Your story'
+                                        onClick={openStory}
+                                    />
+                                ))
+                            ) : (
+                                <div className='flex flex-col items-center justify-center text-xs text-gray-500'>
+                                    <Avatar className='h-16 w-16 mb-1'>
+                                        <AvatarImage src={user?.profilePicture} />
+                                        <AvatarFallback>YOU</AvatarFallback>
+                                    </Avatar>
+                                    <span>Create a story to share</span>
+                                </div>
+                            )
+                        }
+                        {
+                            orderedStories.map((story) => (
+                                <StoryBubble
+                                    key={story._id}
+                                    story={story}
+                                    label={story.owner?.username}
+                                    onClick={openStory}
+                                />
+                            ))
+                        }
+                    </div>
+                )
+            }
+            <StoryViewer story={activeStory} open={viewerOpen} onOpenChange={setViewerOpen} />
+        </div>
+    );
+};
+
+export default StoriesBar;

--- a/frontend/src/components/StoryComposer.jsx
+++ b/frontend/src/components/StoryComposer.jsx
@@ -1,0 +1,126 @@
+import React, { useState, useRef, useEffect } from 'react';
+import { Dialog, DialogContent, DialogHeader } from './ui/dialog';
+import { Button } from './ui/button';
+import { Textarea } from './ui/textarea';
+import { useDispatch, useSelector } from 'react-redux';
+import { Avatar, AvatarFallback, AvatarImage } from './ui/avatar';
+import { readFileAsDataURL } from '@/lib/utils';
+import axios from 'axios';
+import { Loader2 } from 'lucide-react';
+import { toast } from 'sonner';
+import { addStory } from '@/redux/storySlice';
+
+const StoryComposer = () => {
+    const { user } = useSelector(store => store.auth);
+    const dispatch = useDispatch();
+    const [open, setOpen] = useState(false);
+    const [mediaPreview, setMediaPreview] = useState('');
+    const [mediaFile, setMediaFile] = useState(null);
+    const [caption, setCaption] = useState('');
+    const [loading, setLoading] = useState(false);
+    const fileInputRef = useRef();
+
+    const handleFileChange = async (event) => {
+        const file = event.target.files?.[0];
+        if (!file) return;
+        setMediaFile(file);
+        if(file.type.startsWith('image/')){
+            const preview = await readFileAsDataURL(file);
+            setMediaPreview(preview);
+        }else{
+            setMediaPreview(URL.createObjectURL(file));
+        }
+    };
+
+    const resetComposer = () => {
+        setMediaPreview('');
+        setMediaFile(null);
+        setCaption('');
+        setOpen(false);
+    };
+
+    const handleSubmit = async () => {
+        if(!mediaFile){
+            toast.error('Please select an image or video');
+            return;
+        }
+        const formData = new FormData();
+        formData.append('caption', caption);
+        formData.append('media', mediaFile);
+        try {
+            setLoading(true);
+            const res = await axios.post('https://let-s-talk-lq7h.onrender.com/api/v1/story', formData, {
+                headers: { 'Content-Type': 'multipart/form-data' },
+                withCredentials: true
+            });
+            if(res.data.success){
+                dispatch(addStory(res.data.story));
+                toast.success('Story added');
+                resetComposer();
+            }
+        } catch (error) {
+            console.log(error);
+            toast.error(error?.response?.data?.message || 'Unable to add story');
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        if(mediaPreview && mediaFile && !mediaFile.type.startsWith('image/')){
+            return () => URL.revokeObjectURL(mediaPreview);
+        }
+    }, [mediaPreview, mediaFile]);
+
+    return (
+        <>
+            <Button variant='outline' className='w-full justify-start text-sm' onClick={() => setOpen(true)}>Share story</Button>
+            <Dialog open={open} onOpenChange={(value) => value ? setOpen(true) : resetComposer()}>
+                <DialogContent onInteractOutside={resetComposer}>
+                    <DialogHeader className='text-center font-semibold'>Create story</DialogHeader>
+                    <div className='flex items-center gap-3'>
+                        <Avatar>
+                            <AvatarImage src={user?.profilePicture} alt='profile' />
+                            <AvatarFallback>CN</AvatarFallback>
+                        </Avatar>
+                        <div className='flex flex-col'>
+                            <span className='text-sm font-semibold'>{user?.username}</span>
+                            <span className='text-xs text-gray-500'>Stories disappear after 24h</span>
+                        </div>
+                    </div>
+                    <Textarea
+                        value={caption}
+                        onChange={(e) => setCaption(e.target.value)}
+                        placeholder='Add a caption (optional)'
+                        className='focus-visible:ring-transparent'
+                    />
+                    {
+                        mediaPreview && (
+                            mediaFile?.type?.startsWith('image/') ? (
+                                <img src={mediaPreview} alt='preview' className='w-full rounded-xl object-cover max-h-80' />
+                            ) : (
+                                <video src={mediaPreview} controls className='w-full rounded-xl max-h-80' />
+                            )
+                        )
+                    }
+                    <input type='file' accept='image/*,video/*' ref={fileInputRef} onChange={handleFileChange} className='hidden' />
+                    <div className='flex gap-3 justify-end'>
+                        <Button variant='secondary' onClick={() => fileInputRef.current?.click()}>Select media</Button>
+                        {
+                            loading ? (
+                                <Button disabled>
+                                    <Loader2 className='mr-2 h-4 w-4 animate-spin' />
+                                    Uploading
+                                </Button>
+                            ) : (
+                                <Button onClick={handleSubmit} disabled={!mediaFile}>Share</Button>
+                            )
+                        }
+                    </div>
+                </DialogContent>
+            </Dialog>
+        </>
+    );
+};
+
+export default StoryComposer;

--- a/frontend/src/components/StoryViewer.jsx
+++ b/frontend/src/components/StoryViewer.jsx
@@ -1,0 +1,70 @@
+import React, { useEffect } from 'react';
+import { Dialog, DialogContent } from './ui/dialog';
+import { Avatar, AvatarFallback, AvatarImage } from './ui/avatar';
+import { Button } from './ui/button';
+import { X } from 'lucide-react';
+import axios from 'axios';
+import { useDispatch, useSelector } from 'react-redux';
+import { updateStoryViewers } from '@/redux/storySlice';
+
+const StoryViewer = ({ story, open, onOpenChange }) => {
+    const dispatch = useDispatch();
+    const { user } = useSelector(store => store.auth);
+
+    useEffect(() => {
+        const markViewed = async () => {
+            if(!story?._id) return;
+            try {
+                await axios.post(`https://let-s-talk-lq7h.onrender.com/api/v1/story/${story._id}/view`, {}, { withCredentials: true });
+                dispatch(updateStoryViewers({ storyId: story._id, viewerId: user?._id }));
+            } catch (error) {
+                console.log(error);
+            }
+        };
+        if(open){
+            markViewed();
+        }
+    }, [dispatch, open, story?._id, user?._id]);
+
+    if(!story) return null;
+
+    const isImageStory = story.mediaType === 'image';
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent className='max-w-2xl p-0 overflow-hidden'>
+                <div className='flex items-center justify-between px-4 py-2 bg-black text-white'>
+                    <div className='flex items-center gap-3'>
+                        <Avatar className='h-10 w-10'>
+                            <AvatarImage src={story.owner?.profilePicture} />
+                            <AvatarFallback>CN</AvatarFallback>
+                        </Avatar>
+                        <div className='flex flex-col'>
+                            <span className='text-sm font-semibold'>{story.owner?.username}</span>
+                            <span className='text-xs text-gray-300'>{new Date(story.createdAt).toLocaleString()}</span>
+                        </div>
+                    </div>
+                    <Button size='icon' variant='ghost' onClick={() => onOpenChange(false)}>
+                        <X />
+                    </Button>
+                </div>
+                <div className='bg-black flex justify-center items-center max-h-[80vh]'>
+                    {
+                        isImageStory ? (
+                            <img src={story.mediaUrl} alt='story' className='max-h-[80vh] object-contain' />
+                        ) : (
+                            <video src={story.mediaUrl} controls autoPlay className='max-h-[80vh]' />
+                        )
+                    }
+                </div>
+                {story.caption && (
+                    <div className='px-4 py-2 text-sm text-gray-700 bg-white'>
+                        {story.caption}
+                    </div>
+                )}
+            </DialogContent>
+        </Dialog>
+    );
+};
+
+export default StoryViewer;

--- a/frontend/src/hooks/useFollowRequests.jsx
+++ b/frontend/src/hooks/useFollowRequests.jsx
@@ -1,0 +1,46 @@
+import { useCallback, useEffect } from "react";
+import axios from "axios";
+import { useDispatch } from "react-redux";
+import { setFollowRequests, setAuthUser } from "@/redux/authSlice";
+
+const useFollowRequests = () => {
+    const dispatch = useDispatch();
+
+    const fetchFollowRequests = useCallback(async () => {
+        try {
+            const res = await axios.get('https://let-s-talk-lq7h.onrender.com/api/v1/user/follow-requests', { withCredentials: true });
+            if (res.data.success) {
+                dispatch(setFollowRequests(res.data.requests));
+            }
+        } catch (error) {
+            console.log(error);
+        }
+    }, [dispatch]);
+
+    useEffect(() => {
+        fetchFollowRequests();
+    }, [fetchFollowRequests]);
+
+    const respondToRequest = useCallback(async ({ requesterId, action }) => {
+        try {
+            const res = await axios.post('https://let-s-talk-lq7h.onrender.com/api/v1/user/follow-requests/respond', {
+                requesterId,
+                action
+            }, { withCredentials: true });
+            if(res.data.success){
+                dispatch(setFollowRequests(res.data.requests));
+                if(res.data.user){
+                    dispatch(setAuthUser(res.data.user));
+                }
+            }
+            return res.data;
+        } catch (error) {
+            console.log(error);
+            throw error;
+        }
+    }, [dispatch]);
+
+    return { fetchFollowRequests, respondToRequest };
+};
+
+export default useFollowRequests;

--- a/frontend/src/hooks/useGetUserProfile.jsx
+++ b/frontend/src/hooks/useGetUserProfile.jsx
@@ -1,24 +1,28 @@
 import { setUserProfile } from "@/redux/authSlice";
 import axios from "axios";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect } from "react";
 import { useDispatch } from "react-redux";
 
 
 const useGetUserProfile = (userId) => {
     const dispatch = useDispatch();
     // const [userProfile, setUserProfile] = useState(null);
-    useEffect(() => {
-        const fetchUserProfile = async () => {
-            try {
-                const res = await axios.get(`https://let-s-talk-lq7h.onrender.com/api/v1/user/${userId}/profile`, { withCredentials: true });
-                if (res.data.success) { 
-                    dispatch(setUserProfile(res.data.user));
-                }
-            } catch (error) {
-                console.log(error);
+    const fetchUserProfile = useCallback(async () => {
+        if(!userId) return;
+        try {
+            const res = await axios.get(`https://let-s-talk-lq7h.onrender.com/api/v1/user/${userId}/profile`, { withCredentials: true });
+            if (res.data.success) {
+                dispatch(setUserProfile({ user: res.data.user, meta: res.data.meta }));
             }
+        } catch (error) {
+            console.log(error);
         }
+    }, [dispatch, userId]);
+
+    useEffect(() => {
         fetchUserProfile();
-    }, [userId]);
+    }, [fetchUserProfile]);
+
+    return { refetch: fetchUserProfile };
 };
 export default useGetUserProfile;

--- a/frontend/src/hooks/useReels.jsx
+++ b/frontend/src/hooks/useReels.jsx
@@ -1,0 +1,34 @@
+import { useCallback, useEffect } from "react";
+import axios from "axios";
+import { useDispatch } from "react-redux";
+import { addReel, setReelLoading, setReels } from "@/redux/reelSlice";
+
+const useReels = () => {
+    const dispatch = useDispatch();
+
+    const fetchReels = useCallback(async () => {
+        try {
+            dispatch(setReelLoading(true));
+            const res = await axios.get('https://let-s-talk-lq7h.onrender.com/api/v1/reel', { withCredentials: true });
+            if (res.data.success) {
+                dispatch(setReels(res.data.reels));
+            }
+        } catch (error) {
+            console.log(error);
+        } finally {
+            dispatch(setReelLoading(false));
+        }
+    }, [dispatch]);
+
+    useEffect(() => {
+        fetchReels();
+    }, [fetchReels]);
+
+    const prependReel = useCallback((reel) => {
+        dispatch(addReel(reel));
+    }, [dispatch]);
+
+    return { refetchReels: fetchReels, prependReel };
+};
+
+export default useReels;

--- a/frontend/src/hooks/useStoryFeed.jsx
+++ b/frontend/src/hooks/useStoryFeed.jsx
@@ -1,0 +1,31 @@
+import { useCallback, useEffect } from "react";
+import axios from "axios";
+import { useDispatch } from "react-redux";
+import { setStoryLoading, setMyStories, setStories } from "@/redux/storySlice";
+
+const useStoryFeed = () => {
+    const dispatch = useDispatch();
+
+    const fetchStories = useCallback(async () => {
+        try {
+            dispatch(setStoryLoading(true));
+            const res = await axios.get('https://let-s-talk-lq7h.onrender.com/api/v1/story/feed', { withCredentials: true });
+            if (res.data.success) {
+                dispatch(setMyStories(res.data.myStories));
+                dispatch(setStories(res.data.feedStories));
+            }
+        } catch (error) {
+            console.log(error);
+        } finally {
+            dispatch(setStoryLoading(false));
+        }
+    }, [dispatch]);
+
+    useEffect(() => {
+        fetchStories();
+    }, [fetchStories]);
+
+    return { refetchStories: fetchStories };
+};
+
+export default useStoryFeed;

--- a/frontend/src/redux/authSlice.js
+++ b/frontend/src/redux/authSlice.js
@@ -6,18 +6,25 @@ const authSlice = createSlice({
         user:null,
         suggestedUsers:[],
         userProfile:null,
+        userProfileMeta:null,
+        followRequests:[],
         selectedUser:null,
     },
     reducers:{
         // actions
         setAuthUser:(state,action) => {
             state.user = action.payload;
+            state.followRequests = action.payload?.followRequests || [];
         },
         setSuggestedUsers:(state,action) => {
             state.suggestedUsers = action.payload;
         },
         setUserProfile:(state,action) => {
-            state.userProfile = action.payload;
+            state.userProfile = action.payload?.user ?? null;
+            state.userProfileMeta = action.payload?.meta ?? null;
+        },
+        setFollowRequests:(state,action) => {
+            state.followRequests = action.payload ?? [];
         },
         setSelectedUser:(state,action) => {
             state.selectedUser = action.payload;
@@ -25,9 +32,10 @@ const authSlice = createSlice({
     }
 });
 export const {
-    setAuthUser, 
-    setSuggestedUsers, 
+    setAuthUser,
+    setSuggestedUsers,
     setUserProfile,
+    setFollowRequests,
     setSelectedUser,
 } = authSlice.actions;
 export default authSlice.reducer;

--- a/frontend/src/redux/reelSlice.js
+++ b/frontend/src/redux/reelSlice.js
@@ -1,0 +1,38 @@
+import { createSlice } from "@reduxjs/toolkit";
+
+const reelSlice = createSlice({
+    name: 'reel',
+    initialState: {
+        reels: [],
+        isLoading: false
+    },
+    reducers: {
+        setReelLoading: (state, action) => {
+            state.isLoading = action.payload;
+        },
+        setReels: (state, action) => {
+            state.reels = action.payload || [];
+        },
+        addReel: (state, action) => {
+            state.reels = [action.payload, ...state.reels];
+        },
+        toggleReelLike: (state, action) => {
+            const { reelId, userId, liked } = action.payload;
+            state.reels = state.reels.map(reel => {
+                if (reel._id === reelId) {
+                    let likes = Array.isArray(reel.likes) ? [...reel.likes] : [];
+                    if (liked) {
+                        if (!likes.includes(userId)) likes.push(userId);
+                    } else {
+                        likes = likes.filter(id => id !== userId);
+                    }
+                    return { ...reel, likes };
+                }
+                return reel;
+            });
+        }
+    }
+});
+
+export const { setReelLoading, setReels, addReel, toggleReelLike } = reelSlice.actions;
+export default reelSlice.reducer;

--- a/frontend/src/redux/store.js
+++ b/frontend/src/redux/store.js
@@ -4,6 +4,8 @@ import postSlice from './postSlice.js';
 import socketSlice from "./socketSlice.js"
 import chatSlice from "./chatSlice.js";
 import rtnSlice from "./rtnSlice.js";
+import storySlice from "./storySlice.js";
+import reelSlice from "./reelSlice.js";
 
 import { 
     persistReducer,
@@ -28,7 +30,9 @@ const rootReducer = combineReducers({
     post:postSlice,
     socketio:socketSlice,
     chat:chatSlice,
-    realTimeNotification:rtnSlice
+    realTimeNotification:rtnSlice,
+    story:storySlice,
+    reel:reelSlice
 })
 
 const persistedReducer = persistReducer(persistConfig, rootReducer)

--- a/frontend/src/redux/storySlice.js
+++ b/frontend/src/redux/storySlice.js
@@ -1,0 +1,38 @@
+import { createSlice } from "@reduxjs/toolkit";
+
+const storySlice = createSlice({
+    name: 'story',
+    initialState: {
+        myStories: [],
+        stories: [],
+        isLoading: false
+    },
+    reducers: {
+        setStoryLoading: (state, action) => {
+            state.isLoading = action.payload;
+        },
+        setMyStories: (state, action) => {
+            state.myStories = action.payload || [];
+        },
+        setStories: (state, action) => {
+            state.stories = action.payload || [];
+        },
+        addStory: (state, action) => {
+            state.myStories = [action.payload, ...state.myStories];
+        },
+        updateStoryViewers: (state, action) => {
+            const { storyId, viewerId } = action.payload;
+            const updateViewerList = (story) => {
+                if (story._id === storyId && !story.viewers?.includes(viewerId)) {
+                    story.viewers = [...(story.viewers || []), viewerId];
+                }
+                return story;
+            };
+            state.myStories = state.myStories.map(updateViewerList);
+            state.stories = state.stories.map(updateViewerList);
+        }
+    }
+});
+
+export const { setStoryLoading, setMyStories, setStories, addStory, updateStoryViewers } = storySlice.actions;
+export default storySlice.reducer;


### PR DESCRIPTION
## Summary
- add story endpoints, models, and React experiences for creating, viewing, and tracking ephemeral stories
- add reel support with video uploads, feed rendering, likes, and view tracking across backend and frontend
- introduce public/private account settings, follow request workflow, and profile gating aligned with privacy state

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e67964e7a4832686a0dc6e4f18add7