### PR TITLE
Revamp feed layout with NovaSphere-inspired UI

### DIFF
--- a/backend/controllers/post.controller.js
+++ b/backend/controllers/post.controller.js
@@ -47,8 +47,10 @@ export const addNewPost = async (req, res) => {
 }
 export const getAllPost = async (req, res) => {
     try {
+        const viewerId = req.id;
+
         const posts = await Post.find().sort({ createdAt: -1 })
-            .populate({ path: 'author', select: 'username profilePicture' })
+            .populate({ path: 'author', select: 'username profilePicture accountType followers' })
             .populate({
                 path: 'comments',
                 sort: { createdAt: -1 },
@@ -57,8 +59,25 @@ export const getAllPost = async (req, res) => {
                     select: 'username profilePicture'
                 }
             });
+
+        const visiblePosts = posts
+            .filter(post => {
+                const author = post.author;
+                if (!author) return false;
+                if (author.accountType !== 'private') return true;
+                if (author._id.equals(viewerId)) return true;
+                return author.followers.some(followerId => followerId.equals(viewerId));
+            })
+            .map(post => {
+                const serializedPost = post.toObject({ depopulate: false });
+                if (serializedPost.author) {
+                    delete serializedPost.author.followers;
+                }
+                return serializedPost;
+            });
+
         return res.status(200).json({
-            posts,
+            posts: visiblePosts,
             success: true
         })
     } catch (error) {

--- a/backend/controllers/user.controller.js
+++ b/backend/controllers/user.controller.js
@@ -12,6 +12,32 @@ const sanitizeUserForClient = (userDoc) => {
     return user;
 };
 
+const toStringId = (value) => {
+    if(!value) return null;
+    if(typeof value === 'string') return value;
+    if(typeof value === 'number') return value.toString();
+    if(typeof value === 'object'){
+        if(value._id){
+            const nested = toStringId(value._id);
+            if(nested) return nested;
+        }
+        if(value.id){
+            const nested = toStringId(value.id);
+            if(nested) return nested;
+        }
+        if(typeof value.toString === 'function'){
+            const possible = value.toString();
+            if(typeof possible === 'string' && possible !== '[object Object]') return possible;
+        }
+        return null;
+    }
+    if(typeof value.toString === 'function'){
+        const possible = value.toString();
+        if(typeof possible === 'string' && possible !== '[object Object]') return possible;
+    }
+    return null;
+};
+
 export const register = async (req, res) => {
     try {
         const { username, email, password, accountType } = req.body;
@@ -229,6 +255,109 @@ export const getSuggestedUsers = async (req, res) => {
         })
     } catch (error) {
         console.log(error);
+    }
+};
+
+const buildConnectionList = (collection = [], viewerFollowingSet, viewerPendingSet, viewerId) => {
+    return collection
+        .map(entry => {
+            const id = toStringId(entry);
+            if(!id) return null;
+            const plain = typeof entry.toObject === 'function' ? entry.toObject({ getters: true }) : entry;
+
+            return {
+                _id: id,
+                username: plain?.username,
+                profilePicture: plain?.profilePicture,
+                bio: plain?.bio,
+                accountType: plain?.accountType,
+                isFollowing: viewerFollowingSet.has(id),
+                hasPendingRequest: viewerPendingSet.has(id),
+                isViewer: id === viewerId
+            };
+        })
+        .filter(Boolean);
+};
+
+export const getUserFollowersList = async (req, res) => {
+    try {
+        const targetId = req.params.id;
+        const viewerId = req.id;
+        const viewerIdString = viewerId?.toString?.() ?? viewerId;
+
+        const [targetUser, viewer] = await Promise.all([
+            User.findById(targetId)
+                .select('accountType followers username')
+                .populate({ path: 'followers', select: 'username profilePicture bio accountType' }),
+            User.findById(viewerId).select('following sentFollowRequests')
+        ]);
+
+        if(!targetUser){
+            return res.status(404).json({ success:false, message:'User not found' });
+        }
+
+        const isOwner = targetUser._id.equals(viewerId);
+        const isViewerFollowing = targetUser.followers.some(follower => {
+            const followerId = toStringId(follower);
+            return followerId === viewerIdString;
+        });
+
+        const canViewList = targetUser.accountType === 'public' || isOwner || isViewerFollowing;
+
+        if(!canViewList){
+            return res.status(403).json({ success:false, message:'This account is private. Follow to see their followers.' });
+        }
+
+        const viewerFollowingSet = new Set((viewer?.following || []).map(id => id.toString()));
+        const viewerPendingSet = new Set((viewer?.sentFollowRequests || []).map(id => id.toString()));
+
+        const followers = buildConnectionList(targetUser.followers, viewerFollowingSet, viewerPendingSet, viewerIdString);
+
+        return res.status(200).json({ success:true, users: followers });
+    } catch (error) {
+        console.log(error);
+        return res.status(500).json({ success:false, message:'Unable to load followers right now.' });
+    }
+};
+
+export const getUserFollowingList = async (req, res) => {
+    try {
+        const targetId = req.params.id;
+        const viewerId = req.id;
+        const viewerIdString = viewerId?.toString?.() ?? viewerId;
+
+        const [targetUser, viewer] = await Promise.all([
+            User.findById(targetId)
+                .select('accountType followers following username')
+                .populate({ path: 'following', select: 'username profilePicture bio accountType' }),
+            User.findById(viewerId).select('following sentFollowRequests')
+        ]);
+
+        if(!targetUser){
+            return res.status(404).json({ success:false, message:'User not found' });
+        }
+
+        const isOwner = targetUser._id.equals(viewerId);
+        const isViewerFollowing = targetUser.followers.some(follower => {
+            const followerId = toStringId(follower);
+            return followerId === viewerIdString;
+        });
+
+        const canViewList = targetUser.accountType === 'public' || isOwner || isViewerFollowing;
+
+        if(!canViewList){
+            return res.status(403).json({ success:false, message:'This account is private. Follow to see who they follow.' });
+        }
+
+        const viewerFollowingSet = new Set((viewer?.following || []).map(id => id.toString()));
+        const viewerPendingSet = new Set((viewer?.sentFollowRequests || []).map(id => id.toString()));
+
+        const following = buildConnectionList(targetUser.following, viewerFollowingSet, viewerPendingSet, viewerIdString);
+
+        return res.status(200).json({ success:true, users: following });
+    } catch (error) {
+        console.log(error);
+        return res.status(500).json({ success:false, message:'Unable to load following right now.' });
     }
 };
 export const followOrUnfollow = async (req, res) => {

--- a/backend/routes/user.route.js
+++ b/backend/routes/user.route.js
@@ -1,5 +1,5 @@
 import express from "express";
-import { editProfile, followOrUnfollow, getProfile, getSuggestedUsers, login, logout, register, getFollowRequests, respondToFollowRequest } from "../controllers/user.controller.js";
+import { editProfile, followOrUnfollow, getProfile, getSuggestedUsers, login, logout, register, getFollowRequests, respondToFollowRequest, getUserFollowersList, getUserFollowingList } from "../controllers/user.controller.js";
 import isAuthenticated from "../middlewares/isAuthenticated.js";
 import upload from "../middlewares/multer.js";
 
@@ -8,6 +8,8 @@ const router = express.Router();
 router.route('/register').post(register);
 router.route('/login').post(login);
 router.route('/logout').get(logout);
+router.route('/:id/followers').get(isAuthenticated, getUserFollowersList);
+router.route('/:id/following').get(isAuthenticated, getUserFollowingList);
 router.route('/:id/profile').get(isAuthenticated, getProfile);
 router.route('/profile/edit').post(isAuthenticated, upload.single('profilePhoto'), editProfile);
 router.route('/suggested').get(isAuthenticated, getSuggestedUsers);

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,6 +6,7 @@ import Home from './components/Home'
 import Login from './components/Login'
 import MainLayout from './components/MainLayout'
 import Notifications from './components/Notifications'
+import PostDetail from './components/PostDetail'
 import Profile from './components/Profile'
 import Search from './components/Search'
 import Signup from './components/Signup'
@@ -42,6 +43,10 @@ const browserRouter = createBrowserRouter([
       {
         path: '/notifications',
         element: <ProtectedRoutes><Notifications /></ProtectedRoutes>
+      },
+      {
+        path: '/p/:id',
+        element: <ProtectedRoutes><PostDetail /></ProtectedRoutes>
       },
       {
         path: '/account/edit',

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,10 +1,13 @@
 import { useEffect } from 'react'
 import ChatPage from './components/ChatPage'
 import EditProfile from './components/EditProfile'
+import Explore from './components/Explore'
 import Home from './components/Home'
 import Login from './components/Login'
 import MainLayout from './components/MainLayout'
+import Notifications from './components/Notifications'
 import Profile from './components/Profile'
+import Search from './components/Search'
 import Signup from './components/Signup'
 import { createBrowserRouter, RouterProvider } from 'react-router-dom'
 import { io } from "socket.io-client";
@@ -25,8 +28,20 @@ const browserRouter = createBrowserRouter([
         element: <ProtectedRoutes><Home /></ProtectedRoutes>
       },
       {
+        path: '/search',
+        element: <ProtectedRoutes><Search /></ProtectedRoutes>
+      },
+      {
+        path: '/explore',
+        element: <ProtectedRoutes><Explore /></ProtectedRoutes>
+      },
+      {
         path: '/profile/:id',
         element: <ProtectedRoutes> <Profile /></ProtectedRoutes>
+      },
+      {
+        path: '/notifications',
+        element: <ProtectedRoutes><Notifications /></ProtectedRoutes>
       },
       {
         path: '/account/edit',

--- a/frontend/src/components/Explore.jsx
+++ b/frontend/src/components/Explore.jsx
@@ -51,10 +51,10 @@ const Explore = () => {
 
   return (
     <div className='mx-auto flex w-full max-w-6xl flex-col gap-10'>
-      <div className='flex flex-col gap-4 rounded-[2.5rem] border border-slate-800/60 bg-slate-900/60 p-8 shadow-xl shadow-sky-500/10 backdrop-blur-xl'>
+      <div className='flex flex-col gap-4 rounded-[2.5rem] border border-[rgba(0,0,0,0.05)] bg-white/80 p-8 text-[#4a4a4a] shadow-[0_32px_80px_-60px_rgba(51,51,51,0.6)] backdrop-blur-xl'>
         <div className='flex flex-col gap-2'>
-          <h1 className='text-3xl font-semibold text-slate-50'>Explore trending stories</h1>
-          <p className='text-sm text-slate-400'>Dive into the moments people are loving right now across NovaSphere.</p>
+          <h1 className='text-3xl font-semibold text-[#333333]'>Explore trending stories</h1>
+          <p className='text-sm text-[#6f6f6f]'>Dive into the moments people are loving right now across NovaSphere.</p>
         </div>
         <div className='flex flex-wrap gap-3'>
           {FILTERS.map(filter => {
@@ -66,8 +66,8 @@ const Explore = () => {
                 onClick={() => setActiveFilter(filter.id)}
                 className={`flex items-center gap-2 rounded-full border px-4 py-2 text-sm transition ${
                   isActive
-                    ? 'border-sky-400/40 bg-sky-500/20 text-sky-100 shadow-lg shadow-sky-500/20'
-                    : 'border-slate-800/70 bg-slate-950/40 text-slate-300 hover:border-slate-700 hover:bg-slate-900/60 hover:text-slate-100'
+                    ? 'border-[#c8a9f1]/60 bg-gradient-to-r from-[#c8a9f1]/30 via-[#e8d6c6]/30 to-[#f8c8a3]/35 text-[#333333] shadow-[0_18px_42px_-32px_rgba(200,169,241,0.7)]'
+                    : 'border-[rgba(0,0,0,0.05)] bg-white/70 text-[#6f6f6f] hover:border-[rgba(0,0,0,0.08)] hover:bg-white/85 hover:text-[#333333]'
                 }`}
               >
                 <Icon className='h-4 w-4' />
@@ -84,16 +84,16 @@ const Explore = () => {
             <Link
               key={post._id}
               to={`/p/${post._id}`}
-              className='group overflow-hidden rounded-3xl border border-slate-800/60 bg-slate-950/50 shadow-lg shadow-sky-500/10 transition hover:border-slate-700 hover:shadow-sky-500/20'
+              className='group overflow-hidden rounded-3xl border border-[rgba(0,0,0,0.05)] bg-white/80 shadow-[0_28px_60px_-48px_rgba(51,51,51,0.55)] transition hover:border-[rgba(0,0,0,0.08)] hover:shadow-[0_32px_70px_-50px_rgba(200,169,241,0.6)]'
             >
               <div className='relative'>
                 <img src={post.image} alt={post.caption} className='aspect-square w-full object-cover' />
-                <div className='absolute inset-0 flex items-end justify-between bg-gradient-to-t from-slate-950/80 via-transparent to-transparent p-4 opacity-0 transition group-hover:opacity-100'>
+                <div className='absolute inset-0 flex items-end justify-between bg-gradient-to-t from-black/50 via-transparent to-transparent p-4 opacity-0 transition group-hover:opacity-100'>
                   <div>
-                    <p className='text-sm font-semibold text-slate-50'>{post.author?.username}</p>
-                    <p className='text-xs text-slate-300 line-clamp-2'>{post.caption}</p>
+                    <p className='text-sm font-semibold text-white'>{post.author?.username}</p>
+                    <p className='text-xs text-white/80 line-clamp-2'>{post.caption}</p>
                   </div>
-                  <div className='rounded-full bg-slate-900/80 px-3 py-1 text-xs text-slate-200'>
+                  <div className='rounded-full bg-black/40 px-3 py-1 text-xs text-white/85'>
                     {post.likes.length} likes
                   </div>
                 </div>
@@ -106,7 +106,7 @@ const Explore = () => {
               key={reel._id}
               type='button'
               onClick={() => setActiveReel(reel)}
-              className='group overflow-hidden rounded-3xl border border-violet-500/30 bg-slate-950/50 shadow-lg shadow-violet-500/20 transition hover:border-violet-400/50 hover:shadow-violet-500/30'
+              className='group overflow-hidden rounded-3xl border border-[rgba(200,169,241,0.4)] bg-white/80 shadow-[0_28px_60px_-48px_rgba(200,169,241,0.45)] transition hover:border-[#c8a9f1]/60 hover:shadow-[0_32px_72px_-46px_rgba(200,169,241,0.65)]'
             >
               <div className='relative'>
                 <video
@@ -116,22 +116,22 @@ const Explore = () => {
                   playsInline
                   className='aspect-[9/16] w-full object-cover'
                 />
-                <div className='absolute inset-0 flex flex-col justify-between bg-gradient-to-t from-slate-950/80 via-transparent to-transparent p-4 opacity-0 transition group-hover:opacity-100'>
+                <div className='absolute inset-0 flex flex-col justify-between bg-gradient-to-t from-black/55 via-transparent to-transparent p-4 opacity-0 transition group-hover:opacity-100'>
                   <div className='flex items-center gap-3'>
-                    <Avatar className='h-9 w-9 border border-slate-900/80'>
+                    <Avatar className='h-9 w-9 border border-[rgba(255,255,255,0.6)]'>
                       <AvatarImage src={reel.author?.profilePicture} alt={reel.author?.username} />
                       <AvatarFallback>{reel.author?.username?.slice(0, 2)?.toUpperCase() || 'NS'}</AvatarFallback>
                     </Avatar>
                     <div className='flex flex-col'>
-                      <span className='text-sm font-semibold text-slate-50'>{reel.author?.username}</span>
-                      <span className='text-xs text-slate-300'>{reel.views?.length || 0} views</span>
+                      <span className='text-sm font-semibold text-white'>{reel.author?.username}</span>
+                      <span className='text-xs text-white/80'>{reel.views?.length || 0} views</span>
                     </div>
                   </div>
                   <div className='flex items-center justify-between'>
-                    <div className='rounded-full bg-slate-900/80 px-3 py-1 text-xs text-slate-200'>
+                    <div className='rounded-full bg-black/40 px-3 py-1 text-xs text-white/85'>
                       {reel.likes?.length || 0} likes
                     </div>
-                    <span className='inline-flex items-center gap-2 rounded-full bg-violet-500/20 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-violet-200'>
+                    <span className='inline-flex items-center gap-2 rounded-full bg-white/30 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-white'>
                       <PlayCircle className='h-4 w-4' />
                       Watch
                     </span>
@@ -142,30 +142,30 @@ const Explore = () => {
           ))}
 
           {!trendingPosts.length && !trendingReels.length && (
-            <div className='col-span-full rounded-3xl border border-slate-800/60 bg-slate-950/50 p-10 text-center text-sm text-slate-400'>
+            <div className='col-span-full rounded-3xl border border-[rgba(0,0,0,0.05)] bg-white/70 p-10 text-center text-sm text-[#6f6f6f] shadow-[0_24px_60px_-48px_rgba(51,51,51,0.45)]'>
               Nothing to explore just yet. Follow more creators to fill this space with inspiration!
             </div>
           )}
         </div>
 
-        <aside className='flex h-fit flex-col gap-6 rounded-3xl border border-slate-800/60 bg-slate-950/40 p-6'>
-          <div className='flex items-center gap-3 text-slate-100'>
-            <TrendingUp className='h-5 w-5 text-emerald-300' />
-            <span className='text-sm font-semibold uppercase tracking-wide text-slate-300'>Trending hashtags</span>
+        <aside className='flex h-fit flex-col gap-6 rounded-3xl border border-[rgba(0,0,0,0.05)] bg-white/75 p-6 shadow-[0_24px_60px_-52px_rgba(51,51,51,0.45)]'>
+          <div className='flex items-center gap-3 text-[#4a4a4a]'>
+            <TrendingUp className='h-5 w-5 text-[#c8a9f1]' />
+            <span className='text-sm font-semibold uppercase tracking-wide text-[#8c8c8c]'>Trending hashtags</span>
           </div>
           <div className='flex flex-wrap gap-2'>
             {topHashtags.length ? (
               topHashtags.map(([tag, count]) => (
                 <span
                   key={tag}
-                  className='inline-flex items-center gap-2 rounded-full border border-slate-800/70 bg-slate-900/60 px-3 py-1 text-xs text-slate-200'
+                  className='inline-flex items-center gap-2 rounded-full border border-[rgba(0,0,0,0.05)] bg-white/80 px-3 py-1 text-xs text-[#4a4a4a] shadow-[0_10px_24px_-30px_rgba(0,0,0,0.45)]'
                 >
-                  <Hash className='h-3 w-3 text-sky-300' />
+                  <Hash className='h-3 w-3 text-[#c8a9f1]' />
                   {tag} · {count}
                 </span>
               ))
             ) : (
-              <p className='text-xs text-slate-500'>Start a trend by adding hashtags when you post.</p>
+              <p className='text-xs text-[#8c8c8c]'>Start a trend by adding hashtags when you post.</p>
             )}
           </div>
         </aside>

--- a/frontend/src/components/Explore.jsx
+++ b/frontend/src/components/Explore.jsx
@@ -1,0 +1,165 @@
+import { useMemo, useState } from 'react'
+import { Compass, Film, Hash, ImageIcon, TrendingUp } from 'lucide-react'
+import { useSelector } from 'react-redux'
+import useGetAllPost from '@/hooks/useGetAllPost'
+import useReels from '@/hooks/useReels'
+import { Avatar, AvatarFallback, AvatarImage } from './ui/avatar'
+
+const FILTERS = [
+  { id: 'all', label: 'All', icon: Compass },
+  { id: 'posts', label: 'Posts', icon: ImageIcon },
+  { id: 'reels', label: 'Reels', icon: Film }
+]
+
+const Explore = () => {
+  useGetAllPost()
+  useReels()
+
+  const [activeFilter, setActiveFilter] = useState('all')
+  const { posts } = useSelector(store => store.post)
+  const { reels } = useSelector(store => store.reel)
+
+  const topHashtags = useMemo(() => {
+    const hashtagCounts = posts.reduce((acc, post) => {
+      const matches = post?.caption?.match(/#\w+/g) || []
+      matches.forEach(tag => {
+        const normalized = tag.toLowerCase()
+        acc[normalized] = (acc[normalized] || 0) + 1
+      })
+      return acc
+    }, {})
+
+    return Object.entries(hashtagCounts)
+      .sort(([, aCount], [, bCount]) => bCount - aCount)
+      .slice(0, 6)
+  }, [posts])
+
+  const trendingPosts = useMemo(() => {
+    const sorted = [...posts].sort((a, b) => b.likes.length - a.likes.length)
+    if (activeFilter === 'reels') return []
+    return activeFilter === 'posts' ? sorted : sorted.slice(0, 12)
+  }, [activeFilter, posts])
+
+  const trendingReels = useMemo(() => {
+    if (activeFilter === 'posts') return []
+    const sorted = [...reels].sort((a, b) => (b.views?.length || 0) - (a.views?.length || 0))
+    return activeFilter === 'reels' ? sorted : sorted.slice(0, 8)
+  }, [activeFilter, reels])
+
+  return (
+    <div className='mx-auto flex w-full max-w-6xl flex-col gap-10'>
+      <div className='flex flex-col gap-4 rounded-[2.5rem] border border-slate-800/60 bg-slate-900/60 p-8 shadow-xl shadow-sky-500/10 backdrop-blur-xl'>
+        <div className='flex flex-col gap-2'>
+          <h1 className='text-3xl font-semibold text-slate-50'>Explore trending stories</h1>
+          <p className='text-sm text-slate-400'>Dive into the moments people are loving right now across NovaSphere.</p>
+        </div>
+        <div className='flex flex-wrap gap-3'>
+          {FILTERS.map(filter => {
+            const Icon = filter.icon
+            const isActive = filter.id === activeFilter
+            return (
+              <button
+                key={filter.id}
+                onClick={() => setActiveFilter(filter.id)}
+                className={`flex items-center gap-2 rounded-full border px-4 py-2 text-sm transition ${
+                  isActive
+                    ? 'border-sky-400/40 bg-sky-500/20 text-sky-100 shadow-lg shadow-sky-500/20'
+                    : 'border-slate-800/70 bg-slate-950/40 text-slate-300 hover:border-slate-700 hover:bg-slate-900/60 hover:text-slate-100'
+                }`}
+              >
+                <Icon className='h-4 w-4' />
+                {filter.label}
+              </button>
+            )
+          })}
+        </div>
+      </div>
+
+      <div className='grid gap-8 lg:grid-cols-[1fr_280px]'>
+        <div className='grid gap-6 sm:grid-cols-2 xl:grid-cols-3'>
+          {trendingPosts.map(post => (
+            <article
+              key={post._id}
+              className='group overflow-hidden rounded-3xl border border-slate-800/60 bg-slate-950/50 shadow-lg shadow-sky-500/10 transition hover:border-slate-700 hover:shadow-sky-500/20'
+            >
+              <div className='relative'>
+                <img src={post.image} alt={post.caption} className='aspect-square w-full object-cover' />
+                <div className='absolute inset-0 flex items-end justify-between bg-gradient-to-t from-slate-950/80 via-transparent to-transparent p-4 opacity-0 transition group-hover:opacity-100'>
+                  <div>
+                    <p className='text-sm font-semibold text-slate-50'>{post.author?.username}</p>
+                    <p className='text-xs text-slate-300'>{post.caption}</p>
+                  </div>
+                  <div className='rounded-full bg-slate-900/80 px-3 py-1 text-xs text-slate-200'>
+                    {post.likes.length} likes
+                  </div>
+                </div>
+              </div>
+            </article>
+          ))}
+
+          {trendingReels.map(reel => (
+            <article
+              key={reel._id}
+              className='group overflow-hidden rounded-3xl border border-violet-500/30 bg-slate-950/50 shadow-lg shadow-violet-500/20 transition hover:border-violet-400/50 hover:shadow-violet-500/30'
+            >
+              <div className='relative'>
+                <video
+                  src={reel.videoUrl}
+                  muted
+                  loop
+                  playsInline
+                  className='aspect-[9/16] w-full object-cover'
+                />
+                <div className='absolute inset-0 flex flex-col justify-between bg-gradient-to-t from-slate-950/80 via-transparent to-transparent p-4 opacity-0 transition group-hover:opacity-100'>
+                  <div className='flex items-center gap-3'>
+                    <Avatar className='h-9 w-9 border border-slate-900/80'>
+                      <AvatarImage src={reel.author?.profilePicture} alt={reel.author?.username} />
+                      <AvatarFallback>{reel.author?.username?.slice(0, 2)?.toUpperCase() || 'NS'}</AvatarFallback>
+                    </Avatar>
+                    <div className='flex flex-col'>
+                      <span className='text-sm font-semibold text-slate-50'>{reel.author?.username}</span>
+                      <span className='text-xs text-slate-300'>{reel.views?.length || 0} views</span>
+                    </div>
+                  </div>
+                  <div className='rounded-full bg-slate-900/80 px-3 py-1 text-xs text-slate-200'>
+                    {reel.likes?.length || 0} likes
+                  </div>
+                </div>
+              </div>
+            </article>
+          ))}
+
+          {!trendingPosts.length && !trendingReels.length && (
+            <div className='col-span-full rounded-3xl border border-slate-800/60 bg-slate-950/50 p-10 text-center text-sm text-slate-400'>
+              Nothing to explore just yet. Follow more creators to fill this space with inspiration!
+            </div>
+          )}
+        </div>
+
+        <aside className='flex h-fit flex-col gap-6 rounded-3xl border border-slate-800/60 bg-slate-950/40 p-6'>
+          <div className='flex items-center gap-3 text-slate-100'>
+            <TrendingUp className='h-5 w-5 text-emerald-300' />
+            <span className='text-sm font-semibold uppercase tracking-wide text-slate-300'>Trending hashtags</span>
+          </div>
+          <div className='flex flex-wrap gap-2'>
+            {topHashtags.length ? (
+              topHashtags.map(([tag, count]) => (
+                <span
+                  key={tag}
+                  className='inline-flex items-center gap-2 rounded-full border border-slate-800/70 bg-slate-900/60 px-3 py-1 text-xs text-slate-200'
+                >
+                  <Hash className='h-3 w-3 text-sky-300' />
+                  {tag} · {count}
+                </span>
+              ))
+            ) : (
+              <p className='text-xs text-slate-500'>Start a trend by adding hashtags when you post.</p>
+            )}
+          </div>
+        </aside>
+      </div>
+    </div>
+  )
+}
+
+export default Explore

--- a/frontend/src/components/Explore.jsx
+++ b/frontend/src/components/Explore.jsx
@@ -54,7 +54,7 @@ const Explore = () => {
       <div className='flex flex-col gap-4 rounded-xl border border-[var(--color-outline)] bg-[var(--color-surface-raised)] p-8 text-[var(--color-text-muted)] shadow-[0_18px_32px_rgba(0,0,0,0.08)]'>
         <div className='flex flex-col gap-2'>
           <h1 className='text-3xl font-semibold text-[var(--color-text)]'>Explore trending stories</h1>
-          <p className='text-sm text-[var(--color-text-muted)]'>Dive into the moments people are loving right now across NovaSphere.</p>
+          <p className='text-sm text-[var(--color-text-muted)]'>Dive into the moments people are loving right now across Let&apos;s Talk.</p>
         </div>
         <div className='flex flex-wrap gap-3'>
           {FILTERS.map(filter => {

--- a/frontend/src/components/Explore.jsx
+++ b/frontend/src/components/Explore.jsx
@@ -1,9 +1,11 @@
 import { useMemo, useState } from 'react'
-import { Compass, Film, Hash, ImageIcon, TrendingUp } from 'lucide-react'
+import { Compass, Film, Hash, ImageIcon, PlayCircle, TrendingUp } from 'lucide-react'
 import { useSelector } from 'react-redux'
 import useGetAllPost from '@/hooks/useGetAllPost'
 import useReels from '@/hooks/useReels'
 import { Avatar, AvatarFallback, AvatarImage } from './ui/avatar'
+import { Link } from 'react-router-dom'
+import ReelPlayerDialog from './ReelPlayerDialog'
 
 const FILTERS = [
   { id: 'all', label: 'All', icon: Compass },
@@ -16,6 +18,7 @@ const Explore = () => {
   useReels()
 
   const [activeFilter, setActiveFilter] = useState('all')
+  const [activeReel, setActiveReel] = useState(null)
   const { posts } = useSelector(store => store.post)
   const { reels } = useSelector(store => store.reel)
 
@@ -78,8 +81,9 @@ const Explore = () => {
       <div className='grid gap-8 lg:grid-cols-[1fr_280px]'>
         <div className='grid gap-6 sm:grid-cols-2 xl:grid-cols-3'>
           {trendingPosts.map(post => (
-            <article
+            <Link
               key={post._id}
+              to={`/p/${post._id}`}
               className='group overflow-hidden rounded-3xl border border-slate-800/60 bg-slate-950/50 shadow-lg shadow-sky-500/10 transition hover:border-slate-700 hover:shadow-sky-500/20'
             >
               <div className='relative'>
@@ -87,19 +91,21 @@ const Explore = () => {
                 <div className='absolute inset-0 flex items-end justify-between bg-gradient-to-t from-slate-950/80 via-transparent to-transparent p-4 opacity-0 transition group-hover:opacity-100'>
                   <div>
                     <p className='text-sm font-semibold text-slate-50'>{post.author?.username}</p>
-                    <p className='text-xs text-slate-300'>{post.caption}</p>
+                    <p className='text-xs text-slate-300 line-clamp-2'>{post.caption}</p>
                   </div>
                   <div className='rounded-full bg-slate-900/80 px-3 py-1 text-xs text-slate-200'>
                     {post.likes.length} likes
                   </div>
                 </div>
               </div>
-            </article>
+            </Link>
           ))}
 
           {trendingReels.map(reel => (
-            <article
+            <button
               key={reel._id}
+              type='button'
+              onClick={() => setActiveReel(reel)}
               className='group overflow-hidden rounded-3xl border border-violet-500/30 bg-slate-950/50 shadow-lg shadow-violet-500/20 transition hover:border-violet-400/50 hover:shadow-violet-500/30'
             >
               <div className='relative'>
@@ -121,12 +127,18 @@ const Explore = () => {
                       <span className='text-xs text-slate-300'>{reel.views?.length || 0} views</span>
                     </div>
                   </div>
-                  <div className='rounded-full bg-slate-900/80 px-3 py-1 text-xs text-slate-200'>
-                    {reel.likes?.length || 0} likes
+                  <div className='flex items-center justify-between'>
+                    <div className='rounded-full bg-slate-900/80 px-3 py-1 text-xs text-slate-200'>
+                      {reel.likes?.length || 0} likes
+                    </div>
+                    <span className='inline-flex items-center gap-2 rounded-full bg-violet-500/20 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-violet-200'>
+                      <PlayCircle className='h-4 w-4' />
+                      Watch
+                    </span>
                   </div>
                 </div>
               </div>
-            </article>
+            </button>
           ))}
 
           {!trendingPosts.length && !trendingReels.length && (
@@ -158,6 +170,16 @@ const Explore = () => {
           </div>
         </aside>
       </div>
+
+      <ReelPlayerDialog
+        reel={activeReel}
+        open={Boolean(activeReel)}
+        onOpenChange={(open) => {
+          if (!open) {
+            setActiveReel(null)
+          }
+        }}
+      />
     </div>
   )
 }

--- a/frontend/src/components/Explore.jsx
+++ b/frontend/src/components/Explore.jsx
@@ -51,10 +51,10 @@ const Explore = () => {
 
   return (
     <div className='mx-auto flex w-full max-w-6xl flex-col gap-10'>
-      <div className='flex flex-col gap-4 rounded-[2.5rem] border border-[rgba(0,0,0,0.05)] bg-white/80 p-8 text-[#4a4a4a] shadow-[0_32px_80px_-60px_rgba(51,51,51,0.6)] backdrop-blur-xl'>
+      <div className='flex flex-col gap-4 rounded-xl border border-[var(--color-outline)] bg-[var(--color-surface-raised)] p-8 text-[var(--color-text-muted)] shadow-[0_18px_32px_rgba(0,0,0,0.08)]'>
         <div className='flex flex-col gap-2'>
-          <h1 className='text-3xl font-semibold text-[#333333]'>Explore trending stories</h1>
-          <p className='text-sm text-[#6f6f6f]'>Dive into the moments people are loving right now across NovaSphere.</p>
+          <h1 className='text-3xl font-semibold text-[var(--color-text)]'>Explore trending stories</h1>
+          <p className='text-sm text-[var(--color-text-muted)]'>Dive into the moments people are loving right now across NovaSphere.</p>
         </div>
         <div className='flex flex-wrap gap-3'>
           {FILTERS.map(filter => {
@@ -64,10 +64,10 @@ const Explore = () => {
               <button
                 key={filter.id}
                 onClick={() => setActiveFilter(filter.id)}
-                className={`flex items-center gap-2 rounded-full border px-4 py-2 text-sm transition ${
+                className={`flex items-center gap-2 rounded-md border px-4 py-2 text-sm font-medium transition ${
                   isActive
-                    ? 'border-[#c8a9f1]/60 bg-gradient-to-r from-[#c8a9f1]/30 via-[#e8d6c6]/30 to-[#f8c8a3]/35 text-[#333333] shadow-[0_18px_42px_-32px_rgba(200,169,241,0.7)]'
-                    : 'border-[rgba(0,0,0,0.05)] bg-white/70 text-[#6f6f6f] hover:border-[rgba(0,0,0,0.08)] hover:bg-white/85 hover:text-[#333333]'
+                    ? 'border-[var(--color-primary-start)] bg-[var(--color-primary-start)]/15 text-[var(--color-text)]'
+                    : 'border-[var(--color-outline)] bg-[var(--color-surface)] text-[var(--color-text-muted)] hover:border-[var(--color-primary-start)]/40 hover:text-[var(--color-text)]'
                 }`}
               >
                 <Icon className='h-4 w-4' />
@@ -84,7 +84,7 @@ const Explore = () => {
             <Link
               key={post._id}
               to={`/p/${post._id}`}
-              className='group overflow-hidden rounded-3xl border border-[rgba(0,0,0,0.05)] bg-white/80 shadow-[0_28px_60px_-48px_rgba(51,51,51,0.55)] transition hover:border-[rgba(0,0,0,0.08)] hover:shadow-[0_32px_70px_-50px_rgba(200,169,241,0.6)]'
+              className='group overflow-hidden rounded-lg border border-[var(--color-outline)] bg-[var(--color-surface-raised)] shadow-[0_16px_32px_rgba(0,0,0,0.08)] transition hover:-translate-y-1 hover:border-[var(--color-primary-start)]/40 hover:shadow-[0_20px_40px_rgba(0,0,0,0.12)]'
             >
               <div className='relative'>
                 <img src={post.image} alt={post.caption} className='aspect-square w-full object-cover' />
@@ -106,7 +106,7 @@ const Explore = () => {
               key={reel._id}
               type='button'
               onClick={() => setActiveReel(reel)}
-              className='group overflow-hidden rounded-3xl border border-[rgba(200,169,241,0.4)] bg-white/80 shadow-[0_28px_60px_-48px_rgba(200,169,241,0.45)] transition hover:border-[#c8a9f1]/60 hover:shadow-[0_32px_72px_-46px_rgba(200,169,241,0.65)]'
+              className='group overflow-hidden rounded-lg border border-[var(--color-outline)] bg-[var(--color-surface-raised)] shadow-[0_16px_32px_rgba(0,0,0,0.08)] transition hover:-translate-y-1 hover:border-[var(--color-primary-start)]/40 hover:shadow-[0_20px_40px_rgba(0,0,0,0.12)]'
             >
               <div className='relative'>
                 <video
@@ -128,10 +128,10 @@ const Explore = () => {
                     </div>
                   </div>
                   <div className='flex items-center justify-between'>
-                    <div className='rounded-full bg-black/40 px-3 py-1 text-xs text-white/85'>
+                    <div className='rounded-md bg-black/50 px-3 py-1 text-xs text-white/85'>
                       {reel.likes?.length || 0} likes
                     </div>
-                    <span className='inline-flex items-center gap-2 rounded-full bg-white/30 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-white'>
+                    <span className='inline-flex items-center gap-2 rounded-md bg-white/30 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-white'>
                       <PlayCircle className='h-4 w-4' />
                       Watch
                     </span>
@@ -142,30 +142,30 @@ const Explore = () => {
           ))}
 
           {!trendingPosts.length && !trendingReels.length && (
-            <div className='col-span-full rounded-3xl border border-[rgba(0,0,0,0.05)] bg-white/70 p-10 text-center text-sm text-[#6f6f6f] shadow-[0_24px_60px_-48px_rgba(51,51,51,0.45)]'>
+            <div className='col-span-full rounded-lg border border-[var(--color-outline)] bg-[var(--color-surface-raised)] p-10 text-center text-sm text-[var(--color-text-muted)] shadow-[0_16px_32px_rgba(0,0,0,0.08)]'>
               Nothing to explore just yet. Follow more creators to fill this space with inspiration!
             </div>
           )}
         </div>
 
-        <aside className='flex h-fit flex-col gap-6 rounded-3xl border border-[rgba(0,0,0,0.05)] bg-white/75 p-6 shadow-[0_24px_60px_-52px_rgba(51,51,51,0.45)]'>
-          <div className='flex items-center gap-3 text-[#4a4a4a]'>
-            <TrendingUp className='h-5 w-5 text-[#c8a9f1]' />
-            <span className='text-sm font-semibold uppercase tracking-wide text-[#8c8c8c]'>Trending hashtags</span>
+        <aside className='flex h-fit flex-col gap-5 rounded-xl border border-[var(--color-outline)] bg-[var(--color-surface-raised)] p-5 shadow-[0_16px_32px_rgba(0,0,0,0.08)]'>
+          <div className='flex items-center gap-3 text-[var(--color-text-muted)]'>
+            <TrendingUp className='h-5 w-5 text-[var(--color-primary-start)]' />
+            <span className='text-sm font-semibold uppercase tracking-wide text-[var(--color-text-muted)]'>Trending hashtags</span>
           </div>
           <div className='flex flex-wrap gap-2'>
             {topHashtags.length ? (
               topHashtags.map(([tag, count]) => (
                 <span
                   key={tag}
-                  className='inline-flex items-center gap-2 rounded-full border border-[rgba(0,0,0,0.05)] bg-white/80 px-3 py-1 text-xs text-[#4a4a4a] shadow-[0_10px_24px_-30px_rgba(0,0,0,0.45)]'
+                  className='inline-flex items-center gap-2 rounded-md border border-[var(--color-outline)] bg-[var(--color-surface)] px-3 py-1 text-xs font-medium text-[var(--color-text-muted)]'
                 >
                   <Hash className='h-3 w-3 text-[#c8a9f1]' />
                   {tag} · {count}
                 </span>
               ))
             ) : (
-              <p className='text-xs text-[#8c8c8c]'>Start a trend by adding hashtags when you post.</p>
+              <p className='text-xs text-[var(--color-text-muted)]'>Start a trend by adding hashtags when you post.</p>
             )}
           </div>
         </aside>

--- a/frontend/src/components/Feed.jsx
+++ b/frontend/src/components/Feed.jsx
@@ -1,14 +1,15 @@
-import React from 'react'
 import Posts from './Posts'
 import StoriesBar from './StoriesBar'
 import ReelsShelf from './ReelsShelf'
 
 const Feed = () => {
   return (
-    <div className='flex-1 my-8 flex flex-col gap-6 items-center pl-[20%] pr-6'>
+    <div className='flex w-full flex-col items-center gap-6'>
+      <div className='flex w-full max-w-2xl flex-col gap-6'>
         <StoriesBar />
         <ReelsShelf />
-        <Posts/>
+        <Posts />
+      </div>
     </div>
   )
 }

--- a/frontend/src/components/FollowRequests.jsx
+++ b/frontend/src/components/FollowRequests.jsx
@@ -1,55 +1,58 @@
-import React from 'react';
-import { useSelector } from 'react-redux';
-import { Avatar, AvatarFallback, AvatarImage } from './ui/avatar';
-import { Button } from './ui/button';
-import useFollowRequests from '@/hooks/useFollowRequests';
-import { toast } from 'sonner';
+import { useSelector } from 'react-redux'
+import { Avatar, AvatarFallback, AvatarImage } from './ui/avatar'
+import { Button } from './ui/button'
+import useFollowRequests from '@/hooks/useFollowRequests'
+import { toast } from 'sonner'
 
 const FollowRequests = () => {
-    const { followRequests } = useSelector(store => store.auth);
-    const { respondToRequest } = useFollowRequests();
+  const { followRequests } = useSelector(store => store.auth)
+  const { respondToRequest } = useFollowRequests()
 
-    const handleRespond = async (requesterId, action) => {
-        try {
-            const res = await respondToRequest({ requesterId, action });
-            if(res?.success){
-                toast.success(res.message);
-            }
-        } catch (error) {
-            toast.error(error?.response?.data?.message || 'Unable to update request');
-        }
-    };
+  const handleRespond = async (requesterId, action) => {
+    try {
+      const res = await respondToRequest({ requesterId, action })
+      if (res?.success) {
+        toast.success(res.message)
+      }
+    } catch (error) {
+      toast.error(error?.response?.data?.message || 'Unable to update request')
+    }
+  }
 
-    if(!followRequests?.length) return null;
+  if (!followRequests?.length) return null
 
-    return (
-        <div className='mt-8 bg-white border border-gray-200 rounded-2xl p-4 shadow-sm'>
-            <div className='flex items-center justify-between mb-4'>
-                <h2 className='font-semibold text-sm'>Follow requests</h2>
-                <span className='text-xs text-gray-500'>{followRequests.length}</span>
+  return (
+    <div className='rounded-2xl border border-slate-800/60 bg-slate-950/40 p-5 shadow-inner shadow-sky-500/5'>
+      <div className='mb-4 flex items-center justify-between'>
+        <h2 className='text-sm font-semibold text-slate-100'>Follow requests</h2>
+        <span className='rounded-full bg-slate-900/70 px-2 py-0.5 text-xs text-slate-400'>{followRequests.length}</span>
+      </div>
+      <div className='flex flex-col gap-4'>
+        {followRequests.map(request => (
+          <div key={request._id} className='flex items-center justify-between gap-3 rounded-xl border border-slate-800/60 bg-slate-900/60 px-4 py-3'>
+            <div className='flex items-center gap-3'>
+              <Avatar className='h-10 w-10 border border-slate-900'>
+                <AvatarImage src={request.profilePicture} />
+                <AvatarFallback>RQ</AvatarFallback>
+              </Avatar>
+              <div className='flex flex-col'>
+                <span className='text-sm font-semibold text-slate-100'>{request.username}</span>
+                <span className='text-xs text-slate-400'>{request.bio || 'Wants to follow you'}</span>
+              </div>
             </div>
-            <div className='flex flex-col gap-4'>
-                {followRequests.map(request => (
-                    <div key={request._id} className='flex items-center justify-between gap-2'>
-                        <div className='flex items-center gap-3'>
-                            <Avatar className='h-10 w-10'>
-                                <AvatarImage src={request.profilePicture} />
-                                <AvatarFallback>RQ</AvatarFallback>
-                            </Avatar>
-                            <div className='flex flex-col'>
-                                <span className='text-sm font-semibold'>{request.username}</span>
-                                <span className='text-xs text-gray-500'>{request.bio || 'Wants to follow you'}</span>
-                            </div>
-                        </div>
-                        <div className='flex items-center gap-2'>
-                            <Button size='sm' onClick={() => handleRespond(request._id, 'accept')}>Confirm</Button>
-                            <Button size='sm' variant='outline' onClick={() => handleRespond(request._id, 'decline')}>Delete</Button>
-                        </div>
-                    </div>
-                ))}
+            <div className='flex items-center gap-2'>
+              <Button size='sm' className='bg-emerald-400/90 text-slate-950 hover:bg-emerald-300' onClick={() => handleRespond(request._id, 'accept')}>
+                Confirm
+              </Button>
+              <Button size='sm' variant='outline' className='border-slate-700/80 text-slate-300 hover:bg-slate-900/80' onClick={() => handleRespond(request._id, 'decline')}>
+                Delete
+              </Button>
             </div>
-        </div>
-    );
-};
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
 
-export default FollowRequests;
+export default FollowRequests

--- a/frontend/src/components/FollowRequests.jsx
+++ b/frontend/src/components/FollowRequests.jsx
@@ -22,29 +22,29 @@ const FollowRequests = () => {
   if (!followRequests?.length) return null
 
   return (
-    <div className='rounded-2xl border border-slate-800/60 bg-slate-950/40 p-5 shadow-inner shadow-sky-500/5'>
+    <div className='rounded-2xl border border-[rgba(0,0,0,0.05)] bg-white/75 p-5 shadow-[0_22px_45px_-42px_rgba(200,169,241,0.6)]'>
       <div className='mb-4 flex items-center justify-between'>
-        <h2 className='text-sm font-semibold text-slate-100'>Follow requests</h2>
-        <span className='rounded-full bg-slate-900/70 px-2 py-0.5 text-xs text-slate-400'>{followRequests.length}</span>
+        <h2 className='text-sm font-semibold text-[#333333]'>Follow requests</h2>
+        <span className='rounded-full bg-[#f0e9ff] px-2 py-0.5 text-xs text-[#6f6f6f]'>{followRequests.length}</span>
       </div>
       <div className='flex flex-col gap-4'>
         {followRequests.map(request => (
-          <div key={request._id} className='flex items-center justify-between gap-3 rounded-xl border border-slate-800/60 bg-slate-900/60 px-4 py-3'>
+          <div key={request._id} className='flex items-center justify-between gap-3 rounded-xl border border-[rgba(0,0,0,0.05)] bg-white/80 px-4 py-3 shadow-[0_12px_28px_-36px_rgba(0,0,0,0.45)]'>
             <div className='flex items-center gap-3'>
-              <Avatar className='h-10 w-10 border border-slate-900'>
+              <Avatar className='h-10 w-10 border border-[rgba(0,0,0,0.05)] bg-white'>
                 <AvatarImage src={request.profilePicture} />
                 <AvatarFallback>RQ</AvatarFallback>
               </Avatar>
               <div className='flex flex-col'>
-                <span className='text-sm font-semibold text-slate-100'>{request.username}</span>
-                <span className='text-xs text-slate-400'>{request.bio || 'Wants to follow you'}</span>
+                <span className='text-sm font-semibold text-[#333333]'>{request.username}</span>
+                <span className='text-xs text-[#8c8c8c]'>{request.bio || 'Wants to follow you'}</span>
               </div>
             </div>
             <div className='flex items-center gap-2'>
-              <Button size='sm' className='bg-emerald-400/90 text-slate-950 hover:bg-emerald-300' onClick={() => handleRespond(request._id, 'accept')}>
+              <Button size='sm' className='px-4' onClick={() => handleRespond(request._id, 'accept')}>
                 Confirm
               </Button>
-              <Button size='sm' variant='outline' className='border-slate-700/80 text-slate-300 hover:bg-slate-900/80' onClick={() => handleRespond(request._id, 'decline')}>
+              <Button size='sm' variant='outline' className='border-[rgba(0,0,0,0.08)] text-[#6f6f6f] hover:bg-white/80' onClick={() => handleRespond(request._id, 'decline')}>
                 Delete
               </Button>
             </div>

--- a/frontend/src/components/Home.jsx
+++ b/frontend/src/components/Home.jsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import Feed from './Feed'
 import { Outlet } from 'react-router-dom'
 import RightSidebar from './RightSidebar'
@@ -8,19 +7,22 @@ import useStoryFeed from '@/hooks/useStoryFeed'
 import useReels from '@/hooks/useReels'
 
 const Home = () => {
-    useGetAllPost();
-    useGetSuggestedUsers();
-    useStoryFeed();
-    useReels();
-    return (
-        <div className='flex'>
-            <div className='flex-grow'>
-                <Feed />
-                <Outlet />
-            </div>
-            <RightSidebar />
-        </div>
-    )
+  useGetAllPost()
+  useGetSuggestedUsers()
+  useStoryFeed()
+  useReels()
+
+  return (
+    <div className='flex w-full flex-col gap-6 lg:flex-row'>
+      <div className='flex-1'>
+        <Feed />
+        <Outlet />
+      </div>
+      <div className='w-full lg:w-[320px] xl:w-[360px]'>
+        <RightSidebar />
+      </div>
+    </div>
+  )
 }
 
 export default Home

--- a/frontend/src/components/LeftSidebar.jsx
+++ b/frontend/src/components/LeftSidebar.jsx
@@ -1,121 +1,232 @@
-import { Heart, Home, LogOut, MessageCircle, PlusSquare, Search, TrendingUp } from 'lucide-react'
-import React, { useState } from 'react'
+import { Heart, Home, LogOut, MessageCircle, PlusSquare, Search, Sparkles, TrendingUp } from 'lucide-react'
 import { Avatar, AvatarFallback, AvatarImage } from './ui/avatar'
 import { toast } from 'sonner'
 import axios from 'axios'
-import { useNavigate } from 'react-router-dom'
+import { useLocation, useNavigate } from 'react-router-dom'
 import { useDispatch, useSelector } from 'react-redux'
 import { setAuthUser } from '@/redux/authSlice'
 import CreatePost from './CreatePost'
 import { setPosts, setSelectedPost } from '@/redux/postSlice'
 import { Popover, PopoverContent, PopoverTrigger } from './ui/popover'
 import { Button } from './ui/button'
+import { cn } from '@/lib/utils'
 
-const LeftSidebar = () => {
-    const navigate = useNavigate();
-    const { user } = useSelector(store => store.auth);
-    const { likeNotification } = useSelector(store => store.realTimeNotification);
-    const dispatch = useDispatch();
-    const [open, setOpen] = useState(false);
+const LeftSidebar = ({ mobileOpen, onMobileClose, createOpen, onCreateOpenChange }) => {
+  const navigate = useNavigate()
+  const location = useLocation()
+  const { user } = useSelector(store => store.auth)
+  const { likeNotification } = useSelector(store => store.realTimeNotification)
+  const dispatch = useDispatch()
 
+  const logoutHandler = async () => {
+    try {
+      const res = await axios.get('https://let-s-talk-lq7h.onrender.com/api/v1/user/logout', { withCredentials: true })
+      if (res.data.success) {
+        dispatch(setAuthUser(null))
+        dispatch(setSelectedPost(null))
+        dispatch(setPosts([]))
+        navigate('/login')
+        toast.success(res.data.message)
+      }
+    } catch (error) {
+      toast.error(error.response?.data?.message || 'Unable to logout right now')
+    }
+  }
 
-    const logoutHandler = async () => {
-        try {
-            const res = await axios.get('https://let-s-talk-lq7h.onrender.com/api/v1/user/logout', { withCredentials: true });
-            if (res.data.success) {
-                dispatch(setAuthUser(null));
-                dispatch(setSelectedPost(null));
-                dispatch(setPosts([]));
-                navigate("/login");
-                toast.success(res.data.message);
-            }
-        } catch (error) {
-            toast.error(error.response.data.message);
-        }
+  const routeForItem = (textType) => {
+    switch (textType) {
+      case 'Home':
+        return '/'
+      case 'Messages':
+        return '/chat'
+      case 'Profile':
+        return `/profile/${user?._id}`
+      default:
+        return null
+    }
+  }
+
+  const sidebarHandler = (textType) => {
+    if (textType === 'Logout') {
+      logoutHandler()
+      onMobileClose?.()
+      return
     }
 
-    const sidebarHandler = (textType) => {
-        if (textType === 'Logout') {
-            logoutHandler();
-        } else if (textType === "Create") {
-            setOpen(true);
-        } else if (textType === "Profile") {
-            navigate(`/profile/${user?._id}`);
-        } else if (textType === "Home") {
-            navigate("/");
-        } else if (textType === 'Messages') {
-            navigate("/chat");
-        }
+    if (textType === 'Create') {
+      onCreateOpenChange?.(true)
+      onMobileClose?.()
+      return
     }
 
-    const sidebarItems = [
-        { icon: <Home />, text: "Home" },
-        { icon: <Search />, text: "Search" },
-        { icon: <TrendingUp />, text: "Explore" },
-        { icon: <MessageCircle />, text: "Messages" },
-        { icon: <Heart />, text: "Notifications" },
-        { icon: <PlusSquare />, text: "Create" },
-        {
-            icon: (
-                <Avatar className='w-6 h-6'>
-                    <AvatarImage src={user?.profilePicture} alt="@shadcn" />
-                    <AvatarFallback>CN</AvatarFallback>
+    if (textType === 'Notifications') {
+      if (!likeNotification.length) {
+        toast.info('You are all caught up!')
+      }
+      return
+    }
+
+    if (textType === 'Search' || textType === 'Explore') {
+      toast('Coming soon', {
+        description: 'We are curating smarter discovery tools for you. Stay tuned!'
+      })
+      return
+    }
+
+    const route = routeForItem(textType)
+    if (route) {
+      navigate(route)
+      onMobileClose?.()
+    }
+  }
+
+  const sidebarItems = [
+    { icon: <Home className='h-5 w-5' />, text: 'Home', helper: 'Curated timeline' },
+    { icon: <Search className='h-5 w-5' />, text: 'Search', helper: 'Find creators & spaces' },
+    { icon: <TrendingUp className='h-5 w-5' />, text: 'Explore', helper: 'Trending topics' },
+    { icon: <MessageCircle className='h-5 w-5' />, text: 'Messages', helper: 'Chat & collaborate' },
+    { icon: <Heart className='h-5 w-5' />, text: 'Notifications', helper: 'Reactions & follows' },
+    { icon: <PlusSquare className='h-5 w-5' />, text: 'Create', helper: 'Share something new' },
+    {
+      icon: (
+        <Avatar className='h-8 w-8 border border-slate-800/80'>
+          <AvatarImage src={user?.profilePicture} alt={user?.username} />
+          <AvatarFallback>ME</AvatarFallback>
+        </Avatar>
+      ),
+      text: 'Profile',
+      helper: 'View your canvas'
+    },
+    { icon: <LogOut className='h-5 w-5' />, text: 'Logout', helper: 'Sign out securely' }
+  ]
+
+  const isActive = (text) => {
+    const route = routeForItem(text)
+    if (!route) return false
+    if (text === 'Profile') {
+      return location.pathname.startsWith(`/profile/${user?._id}`)
+    }
+    return location.pathname === route
+  }
+
+  const notificationBadge = likeNotification.length > 0 && (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          size='icon'
+          className='absolute -right-1 -top-1 h-6 w-6 rounded-full bg-gradient-to-br from-rose-500 via-amber-400 to-amber-300 text-xs font-semibold text-slate-900 shadow-md shadow-rose-500/30 hover:from-rose-400 hover:via-amber-300 hover:to-amber-200'
+        >
+          {likeNotification.length}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className='w-72 border border-slate-800/70 bg-slate-900/80 text-slate-200 backdrop-blur-xl'>
+        <div className='space-y-4 text-sm'>
+          <div>
+            <h4 className='font-semibold text-slate-100'>Latest appreciation</h4>
+            <p className='text-xs text-slate-400'>People who loved your recent work</p>
+          </div>
+          <div className='max-h-60 space-y-3 overflow-y-auto pr-2'>
+            {likeNotification.map(notification => (
+              <div key={notification.userId} className='flex items-center gap-3 rounded-xl border border-slate-800/60 bg-slate-950/60 px-3 py-2'>
+                <Avatar className='h-8 w-8'>
+                  <AvatarImage src={notification.userDetails?.profilePicture} />
+                  <AvatarFallback>CN</AvatarFallback>
                 </Avatar>
-            ),
-            text: "Profile"
-        },
-        { icon: <LogOut />, text: "Logout" },
-    ]
-    return (
-        <div className='fixed top-0 z-10 left-0 px-4 border-r border-gray-300 w-[16%] h-screen'>
-            <div className='flex flex-col'>
-                <h1 className='my-8 pl-3 font-bold text-xl'>LOGO</h1>
-                <div>
-                    {
-                        sidebarItems.map((item, index) => {
-                            return (
-                                <div onClick={() => sidebarHandler(item.text)} key={index} className='flex items-center gap-3 relative hover:bg-gray-100 cursor-pointer rounded-lg p-3 my-3'>
-                                    {item.icon}
-                                    <span>{item.text}</span>
-                                    {
-                                        item.text === "Notifications" && likeNotification.length > 0 && (
-                                            <Popover>
-                                                <PopoverTrigger asChild>
-                                                    <Button size='icon' className="rounded-full h-5 w-5 bg-red-600 hover:bg-red-600 absolute bottom-6 left-6">{likeNotification.length}</Button>
-                                                </PopoverTrigger>
-                                                <PopoverContent>
-                                                    <div>
-                                                        {
-                                                            likeNotification.length === 0 ? (<p>No new notification</p>) : (
-                                                                likeNotification.map((notification) => {
-                                                                    return (
-                                                                        <div key={notification.userId} className='flex items-center gap-2 my-2'>
-                                                                            <Avatar>
-                                                                                <AvatarImage src={notification.userDetails?.profilePicture} />
-                                                                                <AvatarFallback>CN</AvatarFallback>
-                                                                            </Avatar>
-                                                                            <p className='text-sm'><span className='font-bold'>{notification.userDetails?.username}</span> liked your post</p>
-                                                                        </div>
-                                                                    )
-                                                                })
-                                                            )
-                                                        }
-                                                    </div>
-                                                </PopoverContent>
-                                            </Popover>
-                                        )
-                                    }
-                                </div>
-                            )
-                        })
-                    }
-                </div>
-            </div>
-
-            <CreatePost open={open} setOpen={setOpen} />
-
+                <p className='text-xs leading-4 text-slate-300'>
+                  <span className='font-semibold text-slate-100'>{notification.userDetails?.username}</span> liked your post
+                </p>
+              </div>
+            ))}
+          </div>
         </div>
-    )
+      </PopoverContent>
+    </Popover>
+  )
+
+  return (
+    <>
+      <div
+        className={cn(
+          'fixed inset-0 z-40 bg-slate-950/70 backdrop-blur-sm transition-opacity duration-300 lg:hidden',
+          mobileOpen ? 'pointer-events-auto opacity-100' : 'pointer-events-none opacity-0'
+        )}
+        onClick={onMobileClose}
+      />
+      <aside
+        className={cn(
+          'fixed left-3 top-3 z-50 flex h-[calc(100vh-1.5rem)] w-[calc(100%-1.5rem)] max-w-xs flex-col gap-8 overflow-hidden rounded-3xl border border-slate-800/70 bg-slate-900/85 p-6 shadow-2xl shadow-sky-500/10 ring-1 ring-white/5 transition-transform duration-300 lg:static lg:h-[calc(100vh-7rem)] lg:w-72 lg:max-w-none lg:translate-x-0 lg:rounded-[2.5rem] lg:border-slate-800/60 lg:bg-slate-900/70 lg:px-7 lg:py-8',
+          mobileOpen ? 'translate-x-0' : '-translate-x-[110%] lg:translate-x-0'
+        )}
+      >
+        <div className='flex flex-col gap-4 rounded-3xl border border-slate-800/60 bg-slate-950/50 p-5 shadow-inner shadow-sky-500/5'>
+          <div className='flex items-center gap-3'>
+            <Avatar className='h-12 w-12 border border-slate-800/70'>
+              <AvatarImage src={user?.profilePicture} alt={user?.username} />
+              <AvatarFallback>{user?.username?.slice(0, 2)?.toUpperCase() || 'ME'}</AvatarFallback>
+            </Avatar>
+            <div className='flex flex-col'>
+              <span className='text-sm font-semibold text-slate-100'>{user?.username}</span>
+              <span className='text-xs text-slate-400'>{user?.bio || 'Craft your story & inspire others'}</span>
+            </div>
+          </div>
+          <div className='rounded-2xl border border-slate-800/60 bg-gradient-to-br from-slate-950/70 via-slate-900/70 to-slate-950/70 p-4 text-xs text-slate-300 shadow-lg shadow-sky-500/5'>
+            <p className='font-medium text-slate-200'>Daily spark</p>
+            <p className='mt-1 text-slate-400'>Share something uplifting today and keep your streak alive.</p>
+            <Button
+              size='sm'
+              className='mt-3 w-full justify-center bg-gradient-to-r from-sky-500 to-emerald-400 text-slate-950 hover:from-sky-400 hover:to-emerald-300'
+              onClick={() => {
+                onCreateOpenChange?.(true)
+                onMobileClose?.()
+              }}
+            >
+              Create post
+            </Button>
+          </div>
+        </div>
+
+        <nav className='flex flex-1 flex-col gap-2 overflow-y-auto pr-1'>
+          {sidebarItems.map((item, index) => (
+            <button
+              key={index}
+              onClick={() => sidebarHandler(item.text)}
+              className={cn(
+                'group relative flex items-center justify-between gap-3 rounded-2xl border border-transparent px-4 py-3 text-left transition-all duration-200',
+                isActive(item.text)
+                  ? 'border-sky-500/30 bg-gradient-to-r from-sky-500/15 via-emerald-400/10 to-emerald-400/20 text-sky-100 shadow-lg shadow-sky-500/20'
+                  : 'text-slate-300 hover:border-slate-700/70 hover:bg-slate-900/70 hover:text-slate-100'
+              )}
+            >
+              <div className='flex items-center gap-3'>
+                <span className={cn('flex h-9 w-9 items-center justify-center rounded-2xl bg-slate-900/60 text-slate-300 transition-colors duration-200', isActive(item.text) && 'bg-sky-500/20 text-sky-200 shadow-inner shadow-sky-500/20')}>
+                  {item.icon}
+                </span>
+                <div className='flex flex-col'>
+                  <span className='text-sm font-medium'>{item.text}</span>
+                  <span className='text-[11px] text-slate-500 group-hover:text-slate-400'>{item.helper}</span>
+                </div>
+              </div>
+              {item.text === 'Notifications' && notificationBadge}
+            </button>
+          ))}
+        </nav>
+
+        <div className='rounded-3xl border border-slate-800/60 bg-slate-950/40 p-5 text-xs text-slate-400 shadow-inner shadow-sky-500/5'>
+          <div className='flex items-start gap-3'>
+            <div className='rounded-2xl bg-sky-500/20 p-2 text-sky-200'>
+              <Sparkles className='h-4 w-4' />
+            </div>
+            <div className='space-y-2'>
+              <p className='font-semibold text-slate-100'>Need a spark?</p>
+              <p>Jump into Explore to find creators and conversations tailored for you.</p>
+            </div>
+          </div>
+        </div>
+
+        <CreatePost open={createOpen} setOpen={onCreateOpenChange} />
+      </aside>
+    </>
+  )
 }
 
 export default LeftSidebar

--- a/frontend/src/components/LeftSidebar.jsx
+++ b/frontend/src/components/LeftSidebar.jsx
@@ -84,7 +84,7 @@ const LeftSidebar = ({ mobileOpen, onMobileClose, createOpen, onCreateOpenChange
     { icon: <PlusSquare className='h-5 w-5' />, text: 'Create', helper: 'Share something new' },
     {
       icon: (
-        <Avatar className='h-8 w-8 border border-slate-800/80'>
+        <Avatar className='h-8 w-8 border border-[rgba(0,0,0,0.05)] bg-white'>
           <AvatarImage src={user?.profilePicture} alt={user?.username} />
           <AvatarFallback>ME</AvatarFallback>
         </Avatar>
@@ -105,7 +105,7 @@ const LeftSidebar = ({ mobileOpen, onMobileClose, createOpen, onCreateOpenChange
   }
 
   const notificationBadge = likeNotification.length > 0 && (
-    <span className='absolute -right-1 -top-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-gradient-to-br from-rose-500 via-amber-400 to-amber-300 text-xs font-semibold text-slate-900 shadow-md shadow-rose-500/30'>
+    <span className='absolute -right-1 -top-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-gradient-to-br from-[#c8a9f1] via-[#d5b69d] to-[#f8c8a3] text-xs font-semibold text-[#333333] shadow-sm shadow-[rgba(200,169,241,0.35)]'>
       {likeNotification.length}
     </span>
   )
@@ -114,34 +114,34 @@ const LeftSidebar = ({ mobileOpen, onMobileClose, createOpen, onCreateOpenChange
     <>
       <div
         className={cn(
-          'fixed inset-0 z-40 bg-slate-950/70 backdrop-blur-sm transition-opacity duration-300 lg:hidden',
+          'fixed inset-0 z-40 bg-black/20 backdrop-blur-sm transition-opacity duration-300 lg:hidden',
           mobileOpen ? 'pointer-events-auto opacity-100' : 'pointer-events-none opacity-0'
         )}
         onClick={onMobileClose}
       />
       <aside
         className={cn(
-          'fixed left-3 top-3 z-50 flex h-[calc(100vh-1.5rem)] w-[calc(100%-1.5rem)] max-w-xs flex-col gap-8 overflow-hidden rounded-3xl border border-slate-800/70 bg-slate-900/85 p-6 shadow-2xl shadow-sky-500/10 ring-1 ring-white/5 transition-transform duration-300 lg:static lg:h-[calc(100vh-7rem)] lg:w-72 lg:max-w-none lg:translate-x-0 lg:rounded-[2.5rem] lg:border-slate-800/60 lg:bg-slate-900/70 lg:px-7 lg:py-8',
+          'fixed left-3 top-3 z-50 flex h-[calc(100vh-1.5rem)] w-[calc(100%-1.5rem)] max-w-xs flex-col gap-8 overflow-hidden rounded-3xl border border-[rgba(0,0,0,0.05)] bg-white/90 p-6 shadow-[0_30px_60px_-45px_rgba(51,51,51,0.65)] ring-1 ring-white/40 transition-transform duration-300 lg:static lg:h-[calc(100vh-7rem)] lg:w-72 lg:max-w-none lg:translate-x-0 lg:rounded-[2.5rem] lg:border-[rgba(0,0,0,0.05)] lg:bg-white/80 lg:px-7 lg:py-8',
           mobileOpen ? 'translate-x-0' : '-translate-x-[110%] lg:translate-x-0'
         )}
       >
-        <div className='flex flex-col gap-4 rounded-3xl border border-slate-800/60 bg-slate-950/50 p-5 shadow-inner shadow-sky-500/5'>
+        <div className='flex flex-col gap-4 rounded-3xl border border-[rgba(0,0,0,0.05)] bg-[rgba(255,255,255,0.85)] p-5 shadow-[inset_0_18px_40px_-38px_rgba(200,169,241,0.6)]'>
           <div className='flex items-center gap-3'>
-            <Avatar className='h-12 w-12 border border-slate-800/70'>
+            <Avatar className='h-12 w-12 border border-[rgba(0,0,0,0.05)] bg-white'>
               <AvatarImage src={user?.profilePicture} alt={user?.username} />
               <AvatarFallback>{user?.username?.slice(0, 2)?.toUpperCase() || 'ME'}</AvatarFallback>
             </Avatar>
             <div className='flex flex-col'>
-              <span className='text-sm font-semibold text-slate-100'>{user?.username}</span>
-              <span className='text-xs text-slate-400'>{user?.bio || 'Craft your story & inspire others'}</span>
+              <span className='text-sm font-semibold text-[#4a4a4a]'>{user?.username}</span>
+              <span className='text-xs text-[#6f6f6f]'>{user?.bio || 'Craft your story & inspire others'}</span>
             </div>
           </div>
-          <div className='rounded-2xl border border-slate-800/60 bg-gradient-to-br from-slate-950/70 via-slate-900/70 to-slate-950/70 p-4 text-xs text-slate-300 shadow-lg shadow-sky-500/5'>
-            <p className='font-medium text-slate-200'>Daily spark</p>
-            <p className='mt-1 text-slate-400'>Share something uplifting today and keep your streak alive.</p>
+          <div className='rounded-2xl border border-[rgba(0,0,0,0.04)] bg-gradient-to-br from-[#fbf7ff] via-white to-[#fff8f3] p-4 text-xs text-[#4a4a4a] shadow-[0_20px_35px_-40px_rgba(200,169,241,0.7)]'>
+            <p className='font-medium text-[#333333]'>Daily spark</p>
+            <p className='mt-1 text-[#6f6f6f]'>Share something uplifting today and keep your streak alive.</p>
             <Button
               size='sm'
-              className='mt-3 w-full justify-center bg-gradient-to-r from-sky-500 to-emerald-400 text-slate-950 hover:from-sky-400 hover:to-emerald-300'
+              className='mt-3 w-full justify-center'
               onClick={() => {
                 onCreateOpenChange?.(true)
                 onMobileClose?.()
@@ -160,17 +160,17 @@ const LeftSidebar = ({ mobileOpen, onMobileClose, createOpen, onCreateOpenChange
               className={cn(
                 'group relative flex items-center justify-between gap-3 rounded-2xl border border-transparent px-4 py-3 text-left transition-all duration-200',
                 isActive(item.text)
-                  ? 'border-sky-500/30 bg-gradient-to-r from-sky-500/15 via-emerald-400/10 to-emerald-400/20 text-sky-100 shadow-lg shadow-sky-500/20'
-                  : 'text-slate-300 hover:border-slate-700/70 hover:bg-slate-900/70 hover:text-slate-100'
+                  ? 'border-[#c8a9f1]/60 bg-gradient-to-r from-[#c8a9f1]/35 via-[#e8d6c6]/30 to-[#f8c8a3]/40 text-[#4a4a4a] shadow-[0_18px_42px_-32px_rgba(200,169,241,0.8)]'
+                  : 'text-[#4a4a4a] hover:border-[rgba(0,0,0,0.06)] hover:bg-white/80 hover:text-[#333333]'
               )}
             >
               <div className='flex items-center gap-3'>
-                <span className={cn('flex h-9 w-9 items-center justify-center rounded-2xl bg-slate-900/60 text-slate-300 transition-colors duration-200', isActive(item.text) && 'bg-sky-500/20 text-sky-200 shadow-inner shadow-sky-500/20')}>
+                <span className={cn('flex h-9 w-9 items-center justify-center rounded-2xl bg-white/70 text-[#b8b8b8] transition-colors duration-200 shadow-[inset_0_8px_18px_-20px_rgba(0,0,0,0.5)]', isActive(item.text) && 'bg-white text-[#4a4a4a] shadow-[inset_0_0_0_1px_rgba(200,169,241,0.6)]')}>
                   {item.icon}
                 </span>
                 <div className='flex flex-col'>
                   <span className='text-sm font-medium'>{item.text}</span>
-                  <span className='text-[11px] text-slate-500 group-hover:text-slate-400'>{item.helper}</span>
+                  <span className='text-[11px] text-[#8c8c8c] group-hover:text-[#666666]'>{item.helper}</span>
                 </div>
               </div>
               {item.text === 'Notifications' && notificationBadge}
@@ -178,13 +178,13 @@ const LeftSidebar = ({ mobileOpen, onMobileClose, createOpen, onCreateOpenChange
           ))}
         </nav>
 
-        <div className='rounded-3xl border border-slate-800/60 bg-slate-950/40 p-5 text-xs text-slate-400 shadow-inner shadow-sky-500/5'>
+        <div className='rounded-3xl border border-[rgba(0,0,0,0.05)] bg-white/75 p-5 text-xs text-[#6f6f6f] shadow-[inset_0_18px_36px_-40px_rgba(0,0,0,0.45)]'>
           <div className='flex items-start gap-3'>
-            <div className='rounded-2xl bg-sky-500/20 p-2 text-sky-200'>
+            <div className='rounded-2xl bg-[#c8a9f1]/30 p-2 text-[#c8a9f1]'>
               <Sparkles className='h-4 w-4' />
             </div>
             <div className='space-y-2'>
-              <p className='font-semibold text-slate-100'>Need a spark?</p>
+              <p className='font-semibold text-[#333333]'>Need a spark?</p>
               <p>Jump into Explore to find creators and conversations tailored for you.</p>
             </div>
           </div>

--- a/frontend/src/components/LeftSidebar.jsx
+++ b/frontend/src/components/LeftSidebar.jsx
@@ -1,4 +1,4 @@
-import { Heart, Home, LogOut, MessageCircle, PlusSquare, Search, Sparkles, TrendingUp } from 'lucide-react'
+import { Heart, Home, LogOut, MessageCircle, PlusSquare, Search, TrendingUp } from 'lucide-react'
 import { Avatar, AvatarFallback, AvatarImage } from './ui/avatar'
 import { toast } from 'sonner'
 import axios from 'axios'
@@ -16,6 +16,7 @@ const LeftSidebar = ({ mobileOpen, onMobileClose, createOpen, onCreateOpenChange
   const { user } = useSelector(store => store.auth)
   const { likeNotification } = useSelector(store => store.realTimeNotification)
   const dispatch = useDispatch()
+  const currentYear = new Date().getFullYear()
 
   const logoutHandler = async () => {
     try {
@@ -133,7 +134,9 @@ const LeftSidebar = ({ mobileOpen, onMobileClose, createOpen, onCreateOpenChange
             </Avatar>
             <div className='flex flex-col'>
               <span className='text-sm font-semibold text-[var(--color-text)]'>{user?.username}</span>
-              <span className='text-xs text-[var(--color-text-muted)]'>{user?.bio || 'Craft your story & inspire others'}</span>
+              {user?.bio ? (
+                <span className='text-xs text-[var(--color-text-muted)]'>{user.bio}</span>
+              ) : null}
             </div>
           </div>
           <Button
@@ -180,15 +183,8 @@ const LeftSidebar = ({ mobileOpen, onMobileClose, createOpen, onCreateOpenChange
         </nav>
 
         <div className='mt-auto border-t border-[var(--color-outline)] px-5 py-5 text-xs text-[var(--color-text-muted)]'>
-          <div className='flex items-start gap-3'>
-            <div className='flex h-9 w-9 items-center justify-center rounded-md bg-[var(--color-primary-start)]/15 text-[var(--color-primary-start)]'>
-              <Sparkles className='h-4 w-4' />
-            </div>
-            <div className='space-y-1'>
-              <p className='text-sm font-semibold text-[var(--color-text)]'>Need a spark?</p>
-              <p>Jump into Explore to find creators and conversations tailored for you.</p>
-            </div>
-          </div>
+          <p className='font-semibold text-[var(--color-text)]'>Let&apos;s Talk</p>
+          <p>© {currentYear}</p>
         </div>
 
         <CreatePost open={createOpen} setOpen={onCreateOpenChange} />

--- a/frontend/src/components/LeftSidebar.jsx
+++ b/frontend/src/components/LeftSidebar.jsx
@@ -105,7 +105,7 @@ const LeftSidebar = ({ mobileOpen, onMobileClose, createOpen, onCreateOpenChange
   }
 
   const notificationBadge = likeNotification.length > 0 && (
-    <span className='absolute -right-1 -top-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-gradient-to-br from-[#c8a9f1] via-[#d5b69d] to-[#f8c8a3] text-xs font-semibold text-[#333333] shadow-sm shadow-[rgba(200,169,241,0.35)]'>
+    <span className='absolute right-2 top-2 inline-flex h-5 min-w-[20px] items-center justify-center rounded-sm bg-[var(--color-primary-start)] text-[11px] font-semibold text-white'>
       {likeNotification.length}
     </span>
   )
@@ -114,63 +114,64 @@ const LeftSidebar = ({ mobileOpen, onMobileClose, createOpen, onCreateOpenChange
     <>
       <div
         className={cn(
-          'fixed inset-0 z-40 bg-black/20 backdrop-blur-sm transition-opacity duration-300 lg:hidden',
+          'fixed inset-0 z-40 bg-black/40 transition-opacity duration-300 lg:hidden',
           mobileOpen ? 'pointer-events-auto opacity-100' : 'pointer-events-none opacity-0'
         )}
         onClick={onMobileClose}
       />
       <aside
         className={cn(
-          'fixed left-3 top-3 z-50 flex h-[calc(100vh-1.5rem)] w-[calc(100%-1.5rem)] max-w-xs flex-col gap-8 overflow-hidden rounded-3xl border border-[rgba(0,0,0,0.05)] bg-white/90 p-6 shadow-[0_30px_60px_-45px_rgba(51,51,51,0.65)] ring-1 ring-white/40 transition-transform duration-300 lg:static lg:h-[calc(100vh-7rem)] lg:w-72 lg:max-w-none lg:translate-x-0 lg:rounded-[2.5rem] lg:border-[rgba(0,0,0,0.05)] lg:bg-white/80 lg:px-7 lg:py-8',
+          'fixed left-4 top-24 z-50 flex h-[calc(100vh-136px)] w-[min(280px,calc(100%-2rem))] flex-col overflow-hidden rounded-xl border border-[var(--color-outline)] bg-[var(--color-surface-raised)] shadow-[0_16px_40px_rgba(0,0,0,0.08)] transition-transform duration-300 lg:static lg:h-[calc(100vh-120px)] lg:w-64 lg:translate-x-0',
           mobileOpen ? 'translate-x-0' : '-translate-x-[110%] lg:translate-x-0'
         )}
       >
-        <div className='flex flex-col gap-4 rounded-3xl border border-[rgba(0,0,0,0.05)] bg-[rgba(255,255,255,0.85)] p-5 shadow-[inset_0_18px_40px_-38px_rgba(200,169,241,0.6)]'>
+        <div className='space-y-4 border-b border-[var(--color-outline)] px-5 py-6'>
           <div className='flex items-center gap-3'>
-            <Avatar className='h-12 w-12 border border-[rgba(0,0,0,0.05)] bg-white'>
+            <Avatar className='h-12 w-12 border border-[var(--color-outline)] bg-[var(--color-surface)]'>
               <AvatarImage src={user?.profilePicture} alt={user?.username} />
               <AvatarFallback>{user?.username?.slice(0, 2)?.toUpperCase() || 'ME'}</AvatarFallback>
             </Avatar>
             <div className='flex flex-col'>
-              <span className='text-sm font-semibold text-[#4a4a4a]'>{user?.username}</span>
-              <span className='text-xs text-[#6f6f6f]'>{user?.bio || 'Craft your story & inspire others'}</span>
+              <span className='text-sm font-semibold text-[var(--color-text)]'>{user?.username}</span>
+              <span className='text-xs text-[var(--color-text-muted)]'>{user?.bio || 'Craft your story & inspire others'}</span>
             </div>
           </div>
-          <div className='rounded-2xl border border-[rgba(0,0,0,0.04)] bg-gradient-to-br from-[#fbf7ff] via-white to-[#fff8f3] p-4 text-xs text-[#4a4a4a] shadow-[0_20px_35px_-40px_rgba(200,169,241,0.7)]'>
-            <p className='font-medium text-[#333333]'>Daily spark</p>
-            <p className='mt-1 text-[#6f6f6f]'>Share something uplifting today and keep your streak alive.</p>
-            <Button
-              size='sm'
-              className='mt-3 w-full justify-center'
-              onClick={() => {
-                onCreateOpenChange?.(true)
-                onMobileClose?.()
-              }}
-            >
-              Create post
-            </Button>
-          </div>
+          <Button
+            size='sm'
+            className='w-full justify-center'
+            onClick={() => {
+              onCreateOpenChange?.(true)
+              onMobileClose?.()
+            }}
+          >
+            Create post
+          </Button>
         </div>
 
-        <nav className='flex flex-1 flex-col gap-2 overflow-y-auto pr-1'>
+        <nav className='flex flex-1 flex-col gap-1 overflow-y-auto px-3 py-4'>
           {sidebarItems.map((item, index) => (
             <button
               key={index}
               onClick={() => sidebarHandler(item.text)}
               className={cn(
-                'group relative flex items-center justify-between gap-3 rounded-2xl border border-transparent px-4 py-3 text-left transition-all duration-200',
+                'group relative flex items-center justify-between gap-3 rounded-lg border border-transparent px-3 py-2 text-left text-sm font-medium text-[var(--color-text-muted)] transition-colors',
                 isActive(item.text)
-                  ? 'border-[#c8a9f1]/60 bg-gradient-to-r from-[#c8a9f1]/35 via-[#e8d6c6]/30 to-[#f8c8a3]/40 text-[#4a4a4a] shadow-[0_18px_42px_-32px_rgba(200,169,241,0.8)]'
-                  : 'text-[#4a4a4a] hover:border-[rgba(0,0,0,0.06)] hover:bg-white/80 hover:text-[#333333]'
+                  ? 'border-[var(--color-outline)] bg-[var(--color-surface-muted)] text-[var(--color-text)]'
+                  : 'hover:border-[var(--color-outline)] hover:bg-[var(--color-surface)] hover:text-[var(--color-text)]'
               )}
             >
               <div className='flex items-center gap-3'>
-                <span className={cn('flex h-9 w-9 items-center justify-center rounded-2xl bg-white/70 text-[#b8b8b8] transition-colors duration-200 shadow-[inset_0_8px_18px_-20px_rgba(0,0,0,0.5)]', isActive(item.text) && 'bg-white text-[#4a4a4a] shadow-[inset_0_0_0_1px_rgba(200,169,241,0.6)]')}>
+                <span
+                  className={cn(
+                    'flex h-9 w-9 items-center justify-center rounded-md bg-[var(--color-surface)] text-[#9d9d9d] transition-colors',
+                    isActive(item.text) && 'bg-[var(--color-primary-start)]/15 text-[var(--color-text)]'
+                  )}
+                >
                   {item.icon}
                 </span>
                 <div className='flex flex-col'>
-                  <span className='text-sm font-medium'>{item.text}</span>
-                  <span className='text-[11px] text-[#8c8c8c] group-hover:text-[#666666]'>{item.helper}</span>
+                  <span>{item.text}</span>
+                  <span className='text-[11px] font-normal text-[#888888] group-hover:text-[var(--color-text-muted)]'>{item.helper}</span>
                 </div>
               </div>
               {item.text === 'Notifications' && notificationBadge}
@@ -178,13 +179,13 @@ const LeftSidebar = ({ mobileOpen, onMobileClose, createOpen, onCreateOpenChange
           ))}
         </nav>
 
-        <div className='rounded-3xl border border-[rgba(0,0,0,0.05)] bg-white/75 p-5 text-xs text-[#6f6f6f] shadow-[inset_0_18px_36px_-40px_rgba(0,0,0,0.45)]'>
+        <div className='mt-auto border-t border-[var(--color-outline)] px-5 py-5 text-xs text-[var(--color-text-muted)]'>
           <div className='flex items-start gap-3'>
-            <div className='rounded-2xl bg-[#c8a9f1]/30 p-2 text-[#c8a9f1]'>
+            <div className='flex h-9 w-9 items-center justify-center rounded-md bg-[var(--color-primary-start)]/15 text-[var(--color-primary-start)]'>
               <Sparkles className='h-4 w-4' />
             </div>
-            <div className='space-y-2'>
-              <p className='font-semibold text-[#333333]'>Need a spark?</p>
+            <div className='space-y-1'>
+              <p className='text-sm font-semibold text-[var(--color-text)]'>Need a spark?</p>
               <p>Jump into Explore to find creators and conversations tailored for you.</p>
             </div>
           </div>

--- a/frontend/src/components/LeftSidebar.jsx
+++ b/frontend/src/components/LeftSidebar.jsx
@@ -7,7 +7,6 @@ import { useDispatch, useSelector } from 'react-redux'
 import { setAuthUser } from '@/redux/authSlice'
 import CreatePost from './CreatePost'
 import { setPosts, setSelectedPost } from '@/redux/postSlice'
-import { Popover, PopoverContent, PopoverTrigger } from './ui/popover'
 import { Button } from './ui/button'
 import { cn } from '@/lib/utils'
 
@@ -37,8 +36,14 @@ const LeftSidebar = ({ mobileOpen, onMobileClose, createOpen, onCreateOpenChange
     switch (textType) {
       case 'Home':
         return '/'
+      case 'Search':
+        return '/search'
+      case 'Explore':
+        return '/explore'
       case 'Messages':
         return '/chat'
+      case 'Notifications':
+        return '/notifications'
       case 'Profile':
         return `/profile/${user?._id}`
       default:
@@ -59,18 +64,8 @@ const LeftSidebar = ({ mobileOpen, onMobileClose, createOpen, onCreateOpenChange
       return
     }
 
-    if (textType === 'Notifications') {
-      if (!likeNotification.length) {
-        toast.info('You are all caught up!')
-      }
-      return
-    }
-
-    if (textType === 'Search' || textType === 'Explore') {
-      toast('Coming soon', {
-        description: 'We are curating smarter discovery tools for you. Stay tuned!'
-      })
-      return
+    if (textType === 'Notifications' && !likeNotification.length) {
+      toast.info('You are all caught up!')
     }
 
     const route = routeForItem(textType)
@@ -110,37 +105,9 @@ const LeftSidebar = ({ mobileOpen, onMobileClose, createOpen, onCreateOpenChange
   }
 
   const notificationBadge = likeNotification.length > 0 && (
-    <Popover>
-      <PopoverTrigger asChild>
-        <Button
-          size='icon'
-          className='absolute -right-1 -top-1 h-6 w-6 rounded-full bg-gradient-to-br from-rose-500 via-amber-400 to-amber-300 text-xs font-semibold text-slate-900 shadow-md shadow-rose-500/30 hover:from-rose-400 hover:via-amber-300 hover:to-amber-200'
-        >
-          {likeNotification.length}
-        </Button>
-      </PopoverTrigger>
-      <PopoverContent className='w-72 border border-slate-800/70 bg-slate-900/80 text-slate-200 backdrop-blur-xl'>
-        <div className='space-y-4 text-sm'>
-          <div>
-            <h4 className='font-semibold text-slate-100'>Latest appreciation</h4>
-            <p className='text-xs text-slate-400'>People who loved your recent work</p>
-          </div>
-          <div className='max-h-60 space-y-3 overflow-y-auto pr-2'>
-            {likeNotification.map(notification => (
-              <div key={notification.userId} className='flex items-center gap-3 rounded-xl border border-slate-800/60 bg-slate-950/60 px-3 py-2'>
-                <Avatar className='h-8 w-8'>
-                  <AvatarImage src={notification.userDetails?.profilePicture} />
-                  <AvatarFallback>CN</AvatarFallback>
-                </Avatar>
-                <p className='text-xs leading-4 text-slate-300'>
-                  <span className='font-semibold text-slate-100'>{notification.userDetails?.username}</span> liked your post
-                </p>
-              </div>
-            ))}
-          </div>
-        </div>
-      </PopoverContent>
-    </Popover>
+    <span className='absolute -right-1 -top-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-gradient-to-br from-rose-500 via-amber-400 to-amber-300 text-xs font-semibold text-slate-900 shadow-md shadow-rose-500/30'>
+      {likeNotification.length}
+    </span>
   )
 
   return (

--- a/frontend/src/components/MainLayout.jsx
+++ b/frontend/src/components/MainLayout.jsx
@@ -25,7 +25,7 @@ const MainLayout = () => {
             </Button>
             <div className="flex items-center gap-2 rounded-lg border border-[var(--color-outline)] bg-[var(--color-surface)] px-3 py-1.5">
               <Sparkles className="h-5 w-5 text-[var(--color-primary-start)]" />
-              <span className="font-semibold tracking-tight text-[var(--color-text)]">NovaSphere</span>
+              <span className="font-semibold tracking-tight text-[var(--color-text)]">Let&apos;s Talk</span>
             </div>
           </div>
           <div className="hidden flex-1 items-center gap-2 lg:flex">

--- a/frontend/src/components/MainLayout.jsx
+++ b/frontend/src/components/MainLayout.jsx
@@ -1,14 +1,68 @@
-import React from 'react'
+import { useState } from 'react'
 import { Outlet } from 'react-router-dom'
+import { Menu, Search, Sparkles } from 'lucide-react'
 import LeftSidebar from './LeftSidebar'
+import { Button } from './ui/button'
+import { Input } from './ui/input'
 
 const MainLayout = () => {
+  const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false)
+  const [createPostOpen, setCreatePostOpen] = useState(false)
+
   return (
-    <div>
-         <LeftSidebar/>
-        <div>
-            <Outlet/>
+    <div className="min-h-screen bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 text-slate-100">
+      <div className="relative isolate">
+        <div className="pointer-events-none absolute inset-0 -z-10 overflow-hidden">
+          <div className="absolute left-1/2 top-[-10%] h-[480px] w-[480px] -translate-x-1/2 rounded-full bg-sky-500/30 blur-3xl" />
+          <div className="absolute right-[10%] bottom-[-15%] h-[420px] w-[420px] rounded-full bg-emerald-400/20 blur-[140px]" />
         </div>
+        <header className="sticky top-0 z-30 border-b border-slate-800/60 bg-slate-950/70 backdrop-blur-xl">
+          <div className="mx-auto flex w-full max-w-7xl items-center justify-between gap-4 px-4 py-4 sm:px-6 lg:px-10">
+            <div className="flex items-center gap-3">
+              <Button
+                variant="secondary"
+                size="icon"
+                className="lg:hidden bg-slate-900/80 text-slate-100 border border-slate-800/80"
+                onClick={() => setMobileSidebarOpen(true)}
+              >
+                <Menu className="h-5 w-5" />
+              </Button>
+              <div className="flex items-center gap-2 rounded-full border border-slate-800/70 bg-slate-900/70 px-4 py-2 shadow-lg shadow-sky-500/5">
+                <Sparkles className="h-5 w-5 text-emerald-300" />
+                <span className="font-semibold tracking-tight text-slate-50">NovaSphere</span>
+              </div>
+            </div>
+            <div className="hidden flex-1 items-center gap-2 lg:flex">
+              <div className="relative w-full max-w-md">
+                <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-500" />
+                <Input
+                  placeholder="Search people, tags, or spaces"
+                  className="w-full border-slate-800 bg-slate-900/70 pl-10 text-slate-100 placeholder:text-slate-500"
+                />
+              </div>
+            </div>
+            <div className="flex items-center gap-3">
+              <Button
+                onClick={() => setCreatePostOpen(true)}
+                className="hidden bg-gradient-to-r from-sky-500 to-emerald-400 text-slate-950 shadow-lg shadow-sky-500/40 hover:from-sky-400 hover:to-emerald-300 lg:inline-flex"
+              >
+                Share a moment
+              </Button>
+            </div>
+          </div>
+        </header>
+        <div className="mx-auto flex w-full max-w-7xl gap-6 px-4 pb-10 pt-6 sm:px-6 lg:px-10">
+          <LeftSidebar
+            mobileOpen={mobileSidebarOpen}
+            onMobileClose={() => setMobileSidebarOpen(false)}
+            createOpen={createPostOpen}
+            onCreateOpenChange={setCreatePostOpen}
+          />
+          <main className="flex min-h-[calc(100vh-120px)] flex-1 flex-col">
+            <Outlet />
+          </main>
+        </div>
+      </div>
     </div>
   )
 }

--- a/frontend/src/components/MainLayout.jsx
+++ b/frontend/src/components/MainLayout.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Outlet } from 'react-router-dom'
+import { Outlet, useNavigate } from 'react-router-dom'
 import { Menu, Search, Sparkles } from 'lucide-react'
 import LeftSidebar from './LeftSidebar'
 import { Button } from './ui/button'
@@ -8,6 +8,7 @@ import { Input } from './ui/input'
 const MainLayout = () => {
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false)
   const [createPostOpen, setCreatePostOpen] = useState(false)
+  const navigate = useNavigate()
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 text-slate-100">
@@ -38,6 +39,7 @@ const MainLayout = () => {
                 <Input
                   placeholder="Search people, tags, or spaces"
                   className="w-full border-slate-800 bg-slate-900/70 pl-10 text-slate-100 placeholder:text-slate-500"
+                  onFocus={() => navigate('/search')}
                 />
               </div>
             </div>

--- a/frontend/src/components/MainLayout.jsx
+++ b/frontend/src/components/MainLayout.jsx
@@ -11,43 +11,40 @@ const MainLayout = () => {
   const navigate = useNavigate()
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 text-slate-100">
+    <div className="min-h-screen bg-gradient-to-br from-[#c8a9f1]/35 via-[#f6f6f6] to-[#f8c8a3]/25 text-[#333333]">
       <div className="relative isolate">
         <div className="pointer-events-none absolute inset-0 -z-10 overflow-hidden">
-          <div className="absolute left-1/2 top-[-10%] h-[480px] w-[480px] -translate-x-1/2 rounded-full bg-sky-500/30 blur-3xl" />
-          <div className="absolute right-[10%] bottom-[-15%] h-[420px] w-[420px] rounded-full bg-emerald-400/20 blur-[140px]" />
+          <div className="absolute left-1/2 top-[-12%] h-[520px] w-[520px] -translate-x-1/2 rounded-full bg-gradient-to-br from-[#c8a9f1]/30 via-transparent to-[#f8c8a3]/20 blur-[140px]" />
+          <div className="absolute right-[8%] bottom-[-18%] h-[480px] w-[480px] rounded-full bg-gradient-to-br from-[#f8c8a3]/25 via-transparent to-[#c8a9f1]/20 blur-[160px]" />
         </div>
-        <header className="sticky top-0 z-30 border-b border-slate-800/60 bg-slate-950/70 backdrop-blur-xl">
+        <header className="sticky top-0 z-30 border-b border-[rgba(0,0,0,0.05)] bg-white/85 backdrop-blur-xl shadow-[0_8px_30px_-25px_rgba(51,51,51,0.45)]">
           <div className="mx-auto flex w-full max-w-7xl items-center justify-between gap-4 px-4 py-4 sm:px-6 lg:px-10">
             <div className="flex items-center gap-3">
               <Button
                 variant="secondary"
                 size="icon"
-                className="lg:hidden bg-slate-900/80 text-slate-100 border border-slate-800/80"
+                className="lg:hidden border border-[rgba(0,0,0,0.08)] bg-white/80 text-[#4a4a4a] shadow-sm"
                 onClick={() => setMobileSidebarOpen(true)}
               >
                 <Menu className="h-5 w-5" />
               </Button>
-              <div className="flex items-center gap-2 rounded-full border border-slate-800/70 bg-slate-900/70 px-4 py-2 shadow-lg shadow-sky-500/5">
-                <Sparkles className="h-5 w-5 text-emerald-300" />
-                <span className="font-semibold tracking-tight text-slate-50">NovaSphere</span>
+              <div className="flex items-center gap-2 rounded-full border border-[rgba(0,0,0,0.05)] bg-white/80 px-4 py-2 shadow-[0_20px_45px_-40px_rgba(200,169,241,0.8)]">
+                <Sparkles className="h-5 w-5 text-[#c8a9f1]" />
+                <span className="font-semibold tracking-tight text-[#4a4a4a]">NovaSphere</span>
               </div>
             </div>
             <div className="hidden flex-1 items-center gap-2 lg:flex">
               <div className="relative w-full max-w-md">
-                <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-500" />
+                <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[#b8b8b8]" />
                 <Input
                   placeholder="Search people, tags, or spaces"
-                  className="w-full border-slate-800 bg-slate-900/70 pl-10 text-slate-100 placeholder:text-slate-500"
+                  className="w-full border-[rgba(0,0,0,0.06)] bg-white/90 pl-10 text-[#333333] placeholder:text-[#b8b8b8]"
                   onFocus={() => navigate('/search')}
                 />
               </div>
             </div>
             <div className="flex items-center gap-3">
-              <Button
-                onClick={() => setCreatePostOpen(true)}
-                className="hidden bg-gradient-to-r from-sky-500 to-emerald-400 text-slate-950 shadow-lg shadow-sky-500/40 hover:from-sky-400 hover:to-emerald-300 lg:inline-flex"
-              >
+              <Button onClick={() => setCreatePostOpen(true)} className="hidden lg:inline-flex">
                 Share a moment
               </Button>
             </div>

--- a/frontend/src/components/MainLayout.jsx
+++ b/frontend/src/components/MainLayout.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { Outlet, useNavigate } from 'react-router-dom'
-import { Menu, Search, Sparkles } from 'lucide-react'
+import { Menu, Search } from 'lucide-react'
 import LeftSidebar from './LeftSidebar'
 import { Button } from './ui/button'
 import { Input } from './ui/input'
@@ -23,10 +23,9 @@ const MainLayout = () => {
             >
               <Menu className="h-5 w-5" />
             </Button>
-            <div className="flex items-center gap-2 rounded-lg border border-[var(--color-outline)] bg-[var(--color-surface)] px-3 py-1.5">
-              <Sparkles className="h-5 w-5 text-[var(--color-primary-start)]" />
-              <span className="font-semibold tracking-tight text-[var(--color-text)]">Let&apos;s Talk</span>
-            </div>
+          <div className="flex items-center gap-2 rounded-lg border border-[var(--color-outline)] bg-[var(--color-surface)] px-3 py-1.5">
+            <span className="font-semibold tracking-tight text-[var(--color-text)]">Let&apos;s Talk</span>
+          </div>
           </div>
           <div className="hidden flex-1 items-center gap-2 lg:flex">
             <div className="relative w-full max-w-md">

--- a/frontend/src/components/MainLayout.jsx
+++ b/frontend/src/components/MainLayout.jsx
@@ -11,56 +11,50 @@ const MainLayout = () => {
   const navigate = useNavigate()
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-[#c8a9f1]/35 via-[#f6f6f6] to-[#f8c8a3]/25 text-[#333333]">
-      <div className="relative isolate">
-        <div className="pointer-events-none absolute inset-0 -z-10 overflow-hidden">
-          <div className="absolute left-1/2 top-[-12%] h-[520px] w-[520px] -translate-x-1/2 rounded-full bg-gradient-to-br from-[#c8a9f1]/30 via-transparent to-[#f8c8a3]/20 blur-[140px]" />
-          <div className="absolute right-[8%] bottom-[-18%] h-[480px] w-[480px] rounded-full bg-gradient-to-br from-[#f8c8a3]/25 via-transparent to-[#c8a9f1]/20 blur-[160px]" />
-        </div>
-        <header className="sticky top-0 z-30 border-b border-[rgba(0,0,0,0.05)] bg-white/85 backdrop-blur-xl shadow-[0_8px_30px_-25px_rgba(51,51,51,0.45)]">
-          <div className="mx-auto flex w-full max-w-7xl items-center justify-between gap-4 px-4 py-4 sm:px-6 lg:px-10">
-            <div className="flex items-center gap-3">
-              <Button
-                variant="secondary"
-                size="icon"
-                className="lg:hidden border border-[rgba(0,0,0,0.08)] bg-white/80 text-[#4a4a4a] shadow-sm"
-                onClick={() => setMobileSidebarOpen(true)}
-              >
-                <Menu className="h-5 w-5" />
-              </Button>
-              <div className="flex items-center gap-2 rounded-full border border-[rgba(0,0,0,0.05)] bg-white/80 px-4 py-2 shadow-[0_20px_45px_-40px_rgba(200,169,241,0.8)]">
-                <Sparkles className="h-5 w-5 text-[#c8a9f1]" />
-                <span className="font-semibold tracking-tight text-[#4a4a4a]">NovaSphere</span>
-              </div>
-            </div>
-            <div className="hidden flex-1 items-center gap-2 lg:flex">
-              <div className="relative w-full max-w-md">
-                <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[#b8b8b8]" />
-                <Input
-                  placeholder="Search people, tags, or spaces"
-                  className="w-full border-[rgba(0,0,0,0.06)] bg-white/90 pl-10 text-[#333333] placeholder:text-[#b8b8b8]"
-                  onFocus={() => navigate('/search')}
-                />
-              </div>
-            </div>
-            <div className="flex items-center gap-3">
-              <Button onClick={() => setCreatePostOpen(true)} className="hidden lg:inline-flex">
-                Share a moment
-              </Button>
+    <div className="min-h-screen bg-[var(--color-background)] text-[var(--color-text)]">
+      <header className="sticky top-0 z-30 border-b border-[var(--color-outline)] bg-[var(--color-surface-raised)]/95 shadow-[0_2px_12px_rgba(0,0,0,0.04)]">
+        <div className="mx-auto flex w-full max-w-6xl items-center justify-between gap-4 px-4 py-3 sm:px-6 lg:px-8">
+          <div className="flex items-center gap-3">
+            <Button
+              variant="secondary"
+              size="icon"
+              className="lg:hidden border border-[var(--color-outline)] bg-[var(--color-surface)] text-[var(--color-text-muted)]"
+              onClick={() => setMobileSidebarOpen(true)}
+            >
+              <Menu className="h-5 w-5" />
+            </Button>
+            <div className="flex items-center gap-2 rounded-lg border border-[var(--color-outline)] bg-[var(--color-surface)] px-3 py-1.5">
+              <Sparkles className="h-5 w-5 text-[var(--color-primary-start)]" />
+              <span className="font-semibold tracking-tight text-[var(--color-text)]">NovaSphere</span>
             </div>
           </div>
-        </header>
-        <div className="mx-auto flex w-full max-w-7xl gap-6 px-4 pb-10 pt-6 sm:px-6 lg:px-10">
-          <LeftSidebar
-            mobileOpen={mobileSidebarOpen}
-            onMobileClose={() => setMobileSidebarOpen(false)}
-            createOpen={createPostOpen}
-            onCreateOpenChange={setCreatePostOpen}
-          />
-          <main className="flex min-h-[calc(100vh-120px)] flex-1 flex-col">
-            <Outlet />
-          </main>
+          <div className="hidden flex-1 items-center gap-2 lg:flex">
+            <div className="relative w-full max-w-md">
+              <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[#a0a0a0]" />
+              <Input
+                placeholder="Search people, tags, or spaces"
+                className="w-full border-[var(--color-outline)] bg-[var(--color-surface)] pl-10 text-[var(--color-text)] placeholder:text-[#a0a0a0]"
+                onFocus={() => navigate('/search')}
+              />
+            </div>
+          </div>
+          <div className="flex items-center gap-3">
+            <Button onClick={() => setCreatePostOpen(true)} className="hidden lg:inline-flex">
+              Share a moment
+            </Button>
+          </div>
         </div>
+      </header>
+      <div className="mx-auto flex w-full max-w-6xl gap-5 px-4 pb-10 pt-6 sm:px-6 lg:px-8">
+        <LeftSidebar
+          mobileOpen={mobileSidebarOpen}
+          onMobileClose={() => setMobileSidebarOpen(false)}
+          createOpen={createPostOpen}
+          onCreateOpenChange={setCreatePostOpen}
+        />
+        <main className="flex min-h-[calc(100vh-120px)] flex-1 flex-col">
+          <Outlet />
+        </main>
       </div>
     </div>
   )

--- a/frontend/src/components/Notifications.jsx
+++ b/frontend/src/components/Notifications.jsx
@@ -64,21 +64,21 @@ const Notifications = () => {
   }
 
   return (
-    <div className='mx-auto flex w-full max-w-4xl flex-col gap-8 rounded-[2.5rem] border border-slate-800/60 bg-slate-900/60 p-8 shadow-xl shadow-sky-500/10 backdrop-blur-xl'>
+    <div className='mx-auto flex w-full max-w-4xl flex-col gap-8 rounded-[2.5rem] border border-[rgba(0,0,0,0.05)] bg-white/80 p-8 text-[#4a4a4a] shadow-[0_32px_80px_-60px_rgba(51,51,51,0.6)] backdrop-blur-xl'>
       <header className='flex flex-wrap items-center justify-between gap-4'>
         <div>
-          <h1 className='text-3xl font-semibold text-slate-50'>Notifications</h1>
-          <p className='text-sm text-slate-400'>Stay in the loop with the latest reactions and follows.</p>
+          <h1 className='text-3xl font-semibold text-[#333333]'>Notifications</h1>
+          <p className='text-sm text-[#6f6f6f]'>Stay in the loop with the latest reactions and follows.</p>
         </div>
         <div className='flex items-center gap-3'>
-          <div className='flex items-center gap-2 rounded-full border border-slate-800/70 bg-slate-950/50 px-4 py-2 text-xs uppercase tracking-wide text-slate-400'>
-            <BellRing className='h-4 w-4 text-emerald-300' />
+          <div className='flex items-center gap-2 rounded-full border border-[rgba(0,0,0,0.05)] bg-white/80 px-4 py-2 text-xs uppercase tracking-wide text-[#8c8c8c] shadow-[0_16px_30px_-28px_rgba(200,169,241,0.6)]'>
+            <BellRing className='h-4 w-4 text-[#c8a9f1]' />
             Live sync
           </div>
           <Button
             variant='secondary'
             onClick={markAllAsRead}
-            className='flex items-center gap-2 rounded-full border-slate-800/70 bg-slate-900/60 text-xs font-semibold uppercase tracking-wide text-slate-200 hover:border-slate-700 hover:bg-slate-900'
+            className='flex items-center gap-2 rounded-full text-xs font-semibold uppercase tracking-wide'
             disabled={!likeNotification.length}
           >
             <RefreshCw className='h-4 w-4' />
@@ -97,21 +97,21 @@ const Notifications = () => {
             return (
             <article
               key={derivedKey}
-              className='flex flex-wrap items-center justify-between gap-4 rounded-3xl border border-slate-800/60 bg-slate-950/50 p-5 shadow-inner shadow-sky-500/5'
+              className='flex flex-wrap items-center justify-between gap-4 rounded-3xl border border-[rgba(0,0,0,0.05)] bg-white/80 p-5 shadow-[0_24px_60px_-48px_rgba(51,51,51,0.45)]'
             >
               <div className='flex items-center gap-4'>
                 <div className='relative'>
-                  <Avatar className='h-12 w-12 border border-slate-900'>
+                  <Avatar className='h-12 w-12 border border-[rgba(0,0,0,0.05)] bg-white'>
                     <AvatarImage src={primaryUser?.profilePicture} alt={primaryUser?.username} />
                     <AvatarFallback>{primaryUser?.username?.slice(0, 2)?.toUpperCase() || 'NS'}</AvatarFallback>
                   </Avatar>
-                  <span className='absolute -right-1 -top-1 flex h-5 w-5 items-center justify-center rounded-full bg-rose-500 text-[10px] font-semibold text-white shadow shadow-rose-500/40'>
+                  <span className='absolute -right-1 -top-1 flex h-5 w-5 items-center justify-center rounded-full bg-[#d66c6c] text-[10px] font-semibold text-white shadow shadow-[rgba(214,108,108,0.35)]'>
                     <Heart className='h-3 w-3' />
                   </span>
                 </div>
                 <div className='flex flex-col'>
-                  <p className='text-sm text-slate-200'>{buildMessage(notification)}</p>
-                  <span className='text-xs text-slate-500'>
+                  <p className='text-sm text-[#4a4a4a]'>{buildMessage(notification)}</p>
+                  <span className='text-xs text-[#8c8c8c]'>
                     {notification.count > 1 ? `${notification.count} interactions` : 'Just now'}
                   </span>
                 </div>
@@ -124,14 +124,14 @@ const Notifications = () => {
                     className='h-16 w-16 rounded-2xl object-cover'
                   />
                 ) : (
-                  <span className='flex h-16 w-16 items-center justify-center rounded-2xl border border-slate-800/70 bg-slate-900/60 text-slate-500'>
+                  <span className='flex h-16 w-16 items-center justify-center rounded-2xl border border-[rgba(0,0,0,0.05)] bg-white/70 text-[#b8b8b8]'>
                     <ImageIcon className='h-5 w-5' />
                   </span>
                 )}
                 <div className='flex items-center gap-2'>
                   <Button
                     variant='secondary'
-                    className='rounded-full border-slate-800/70 bg-slate-900/60 text-xs font-semibold uppercase tracking-wide text-slate-200 hover:border-slate-700 hover:bg-slate-900'
+                    className='rounded-full text-xs font-semibold uppercase tracking-wide'
                     onClick={() => handleViewPost(notification.postId)}
                     disabled={!notification.postId}
                   >
@@ -139,7 +139,7 @@ const Notifications = () => {
                   </Button>
                   <Button
                     variant='ghost'
-                    className='rounded-full border border-transparent text-xs font-semibold uppercase tracking-wide text-slate-400 hover:border-slate-800/70 hover:bg-slate-900/60 hover:text-slate-200'
+                    className='rounded-full border border-transparent text-xs font-semibold uppercase tracking-wide text-[#8c8c8c] hover:text-[#333333]'
                     onClick={() => dispatch(dismissNotification(derivedKey))}
                   >
                     Mark read
@@ -147,13 +147,13 @@ const Notifications = () => {
                 </div>
               </div>
             </article>
-            )
-          })
-        ) : (
-          <div className='rounded-3xl border border-slate-800/60 bg-slate-950/50 p-12 text-center text-sm text-slate-400'>
-            You&apos;re all caught up. Start engaging with others to see activity here!
-          </div>
-        )}
+          )
+        })
+      ) : (
+        <div className='rounded-3xl border border-[rgba(0,0,0,0.05)] bg-white/70 p-12 text-center text-sm text-[#6f6f6f] shadow-[0_24px_60px_-48px_rgba(51,51,51,0.45)]'>
+          You&apos;re all caught up. Start engaging with others to see activity here!
+        </div>
+      )}
       </section>
     </div>
   )

--- a/frontend/src/components/Notifications.jsx
+++ b/frontend/src/components/Notifications.jsx
@@ -1,0 +1,99 @@
+import { useMemo } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { Avatar, AvatarFallback, AvatarImage } from './ui/avatar'
+import { Button } from './ui/button'
+import { BellRing, Heart, RefreshCw } from 'lucide-react'
+import { clearNotifications } from '@/redux/rtnSlice'
+
+const Notifications = () => {
+  const dispatch = useDispatch()
+  const { likeNotification } = useSelector(store => store.realTimeNotification)
+
+  const groupedNotifications = useMemo(() => {
+    const groups = likeNotification.reduce((acc, notification) => {
+      const key = notification.userId
+      if (!acc[key]) {
+        acc[key] = { ...notification, count: 1 }
+      } else {
+        acc[key].count += 1
+      }
+      return acc
+    }, {})
+
+    return Object.values(groups)
+  }, [likeNotification])
+
+  const markAllAsRead = () => {
+    dispatch(clearNotifications())
+  }
+
+  return (
+    <div className='mx-auto flex w-full max-w-4xl flex-col gap-8 rounded-[2.5rem] border border-slate-800/60 bg-slate-900/60 p-8 shadow-xl shadow-sky-500/10 backdrop-blur-xl'>
+      <header className='flex flex-wrap items-center justify-between gap-4'>
+        <div>
+          <h1 className='text-3xl font-semibold text-slate-50'>Notifications</h1>
+          <p className='text-sm text-slate-400'>Stay in the loop with the latest reactions and follows.</p>
+        </div>
+        <div className='flex items-center gap-3'>
+          <div className='flex items-center gap-2 rounded-full border border-slate-800/70 bg-slate-950/50 px-4 py-2 text-xs uppercase tracking-wide text-slate-400'>
+            <BellRing className='h-4 w-4 text-emerald-300' />
+            Live sync
+          </div>
+          <Button
+            variant='secondary'
+            onClick={markAllAsRead}
+            className='flex items-center gap-2 rounded-full border-slate-800/70 bg-slate-900/60 text-xs font-semibold uppercase tracking-wide text-slate-200 hover:border-slate-700 hover:bg-slate-900'
+            disabled={!likeNotification.length}
+          >
+            <RefreshCw className='h-4 w-4' />
+            Clear all
+          </Button>
+        </div>
+      </header>
+
+      <section className='space-y-4'>
+        {groupedNotifications.length ? (
+          groupedNotifications.map(notification => (
+            <article
+              key={notification.userId}
+              className='flex items-center justify-between gap-4 rounded-3xl border border-slate-800/60 bg-slate-950/50 p-5 shadow-inner shadow-sky-500/5'
+            >
+              <div className='flex items-center gap-4'>
+                <div className='relative'>
+                  <Avatar className='h-12 w-12 border border-slate-900'>
+                    <AvatarImage src={notification.userDetails?.profilePicture} alt={notification.userDetails?.username} />
+                    <AvatarFallback>{notification.userDetails?.username?.slice(0, 2)?.toUpperCase() || 'NS'}</AvatarFallback>
+                  </Avatar>
+                  <span className='absolute -right-1 -top-1 flex h-5 w-5 items-center justify-center rounded-full bg-rose-500 text-[10px] font-semibold text-white shadow shadow-rose-500/40'>
+                    <Heart className='h-3 w-3' />
+                  </span>
+                </div>
+                <div className='flex flex-col'>
+                  <p className='text-sm text-slate-200'>
+                    <span className='font-semibold text-slate-50'>{notification.userDetails?.username}</span>{' '}
+                    appreciated your post
+                  </p>
+                  <span className='text-xs text-slate-500'>
+                    {notification.count > 1 ? `${notification.count} interactions` : 'Just now'}
+                  </span>
+                </div>
+              </div>
+              <Button
+                variant='secondary'
+                className='rounded-full border-slate-800/70 bg-slate-900/60 text-xs font-semibold uppercase tracking-wide text-slate-200 hover:border-slate-700 hover:bg-slate-900'
+              >
+                View post
+              </Button>
+            </article>
+          ))
+        ) : (
+          <div className='rounded-3xl border border-slate-800/60 bg-slate-950/50 p-12 text-center text-sm text-slate-400'>
+            You&apos;re all caught up. Start engaging with others to see activity here!
+          </div>
+        )}
+      </section>
+    </div>
+  )
+}
+
+export default Notifications

--- a/frontend/src/components/Notifications.jsx
+++ b/frontend/src/components/Notifications.jsx
@@ -2,29 +2,65 @@ import { useMemo } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { Avatar, AvatarFallback, AvatarImage } from './ui/avatar'
 import { Button } from './ui/button'
-import { BellRing, Heart, RefreshCw } from 'lucide-react'
-import { clearNotifications } from '@/redux/rtnSlice'
+import { BellRing, Heart, ImageIcon, RefreshCw } from 'lucide-react'
+import { useNavigate } from 'react-router-dom'
+import { clearNotifications, dismissNotification } from '@/redux/rtnSlice'
+import useGetAllPost from '@/hooks/useGetAllPost'
 
 const Notifications = () => {
   const dispatch = useDispatch()
+  const navigate = useNavigate()
+  useGetAllPost()
   const { likeNotification } = useSelector(store => store.realTimeNotification)
+  const { posts } = useSelector(store => store.post)
 
   const groupedNotifications = useMemo(() => {
     const groups = likeNotification.reduce((acc, notification) => {
-      const key = notification.userId
+      const key = notification.postId || notification.userId
       if (!acc[key]) {
-        acc[key] = { ...notification, count: 1 }
+        acc[key] = {
+          postId: notification.postId,
+          count: 1,
+          users: notification.userDetails ? [notification.userDetails] : [],
+          latest: notification
+        }
       } else {
         acc[key].count += 1
+        if (
+          notification.userDetails &&
+          !acc[key].users.some(user => user?._id === notification.userId)
+        ) {
+          acc[key].users.push(notification.userDetails)
+        }
+        acc[key].latest = notification
       }
       return acc
     }, {})
 
-    return Object.values(groups)
+    return Object.values(groups).reverse()
   }, [likeNotification])
 
   const markAllAsRead = () => {
     dispatch(clearNotifications())
+  }
+
+  const buildMessage = (notification) => {
+    if (!notification.users.length) {
+      return notification.latest?.message || 'You have new activity'
+    }
+
+    const [firstUser, ...rest] = notification.users
+    if (!rest.length) {
+      return `${firstUser?.username || 'Someone'} appreciated your post`
+    }
+
+    return `${firstUser?.username || 'Someone'} and ${rest.length} other${rest.length > 1 ? 's' : ''} appreciated your post`
+  }
+
+  const handleViewPost = (postId) => {
+    if (!postId) return
+    navigate(`/p/${postId}`)
+    dispatch(dismissNotification(postId))
   }
 
   return (
@@ -53,39 +89,66 @@ const Notifications = () => {
 
       <section className='space-y-4'>
         {groupedNotifications.length ? (
-          groupedNotifications.map(notification => (
+          groupedNotifications.map(notification => {
+            const previewPost = posts.find(post => post._id === notification.postId)
+            const primaryUser = notification.users[0]
+            const derivedKey = notification.postId || primaryUser?._id || notification.latest?.userId
+
+            return (
             <article
-              key={notification.userId}
-              className='flex items-center justify-between gap-4 rounded-3xl border border-slate-800/60 bg-slate-950/50 p-5 shadow-inner shadow-sky-500/5'
+              key={derivedKey}
+              className='flex flex-wrap items-center justify-between gap-4 rounded-3xl border border-slate-800/60 bg-slate-950/50 p-5 shadow-inner shadow-sky-500/5'
             >
               <div className='flex items-center gap-4'>
                 <div className='relative'>
                   <Avatar className='h-12 w-12 border border-slate-900'>
-                    <AvatarImage src={notification.userDetails?.profilePicture} alt={notification.userDetails?.username} />
-                    <AvatarFallback>{notification.userDetails?.username?.slice(0, 2)?.toUpperCase() || 'NS'}</AvatarFallback>
+                    <AvatarImage src={primaryUser?.profilePicture} alt={primaryUser?.username} />
+                    <AvatarFallback>{primaryUser?.username?.slice(0, 2)?.toUpperCase() || 'NS'}</AvatarFallback>
                   </Avatar>
                   <span className='absolute -right-1 -top-1 flex h-5 w-5 items-center justify-center rounded-full bg-rose-500 text-[10px] font-semibold text-white shadow shadow-rose-500/40'>
                     <Heart className='h-3 w-3' />
                   </span>
                 </div>
                 <div className='flex flex-col'>
-                  <p className='text-sm text-slate-200'>
-                    <span className='font-semibold text-slate-50'>{notification.userDetails?.username}</span>{' '}
-                    appreciated your post
-                  </p>
+                  <p className='text-sm text-slate-200'>{buildMessage(notification)}</p>
                   <span className='text-xs text-slate-500'>
                     {notification.count > 1 ? `${notification.count} interactions` : 'Just now'}
                   </span>
                 </div>
               </div>
-              <Button
-                variant='secondary'
-                className='rounded-full border-slate-800/70 bg-slate-900/60 text-xs font-semibold uppercase tracking-wide text-slate-200 hover:border-slate-700 hover:bg-slate-900'
-              >
-                View post
-              </Button>
+              <div className='flex items-center gap-3'>
+                {previewPost ? (
+                  <img
+                    src={previewPost.image}
+                    alt={previewPost.caption}
+                    className='h-16 w-16 rounded-2xl object-cover'
+                  />
+                ) : (
+                  <span className='flex h-16 w-16 items-center justify-center rounded-2xl border border-slate-800/70 bg-slate-900/60 text-slate-500'>
+                    <ImageIcon className='h-5 w-5' />
+                  </span>
+                )}
+                <div className='flex items-center gap-2'>
+                  <Button
+                    variant='secondary'
+                    className='rounded-full border-slate-800/70 bg-slate-900/60 text-xs font-semibold uppercase tracking-wide text-slate-200 hover:border-slate-700 hover:bg-slate-900'
+                    onClick={() => handleViewPost(notification.postId)}
+                    disabled={!notification.postId}
+                  >
+                    View post
+                  </Button>
+                  <Button
+                    variant='ghost'
+                    className='rounded-full border border-transparent text-xs font-semibold uppercase tracking-wide text-slate-400 hover:border-slate-800/70 hover:bg-slate-900/60 hover:text-slate-200'
+                    onClick={() => dispatch(dismissNotification(derivedKey))}
+                  >
+                    Mark read
+                  </Button>
+                </div>
+              </div>
             </article>
-          ))
+            )
+          })
         ) : (
           <div className='rounded-3xl border border-slate-800/60 bg-slate-950/50 p-12 text-center text-sm text-slate-400'>
             You&apos;re all caught up. Start engaging with others to see activity here!

--- a/frontend/src/components/Post.jsx
+++ b/frontend/src/components/Post.jsx
@@ -104,67 +104,67 @@ const Post = ({ post }) => {
   }
 
   return (
-    <div className='w-full overflow-hidden rounded-[2.25rem] border border-slate-800/60 bg-slate-900/70 shadow-xl shadow-sky-500/10 backdrop-blur-xl'>
+    <div className='w-full overflow-hidden rounded-[2.25rem] border border-[rgba(0,0,0,0.05)] bg-white/85 shadow-[0_30px_80px_-60px_rgba(51,51,51,0.65)] backdrop-blur-xl'>
       <div className='flex items-center justify-between gap-4 px-6 pb-4 pt-6'>
         <div className='flex items-center gap-3'>
-          <div className='rounded-3xl bg-gradient-to-br from-sky-500/40 via-emerald-400/30 to-indigo-500/20 p-[2px]'>
-            <Avatar className='h-12 w-12 border border-slate-900'>
+          <div className='rounded-3xl bg-gradient-to-br from-[#c8a9f1]/40 via-[#e8d6c6]/30 to-[#f8c8a3]/30 p-[2px]'>
+            <Avatar className='h-12 w-12 border border-[rgba(0,0,0,0.05)] bg-white'>
               <AvatarImage src={post.author?.profilePicture} alt='post_image' />
               <AvatarFallback>CN</AvatarFallback>
             </Avatar>
           </div>
           <div className='flex flex-col'>
             <div className='flex items-center gap-3'>
-              <h1 className='text-sm font-semibold text-slate-100'>{post.author?.username}</h1>
-              {user?._id === post.author._id && <Badge className='bg-slate-800/80 text-emerald-300'>Author</Badge>}
+              <h1 className='text-sm font-semibold text-[#333333]'>{post.author?.username}</h1>
+              {user?._id === post.author._id && <Badge className='bg-[#f0e9ff] text-[#6f6f6f]'>Author</Badge>}
             </div>
-            <span className='text-xs text-slate-500'>{new Date(post.createdAt).toLocaleString()}</span>
+            <span className='text-xs text-[#8c8c8c]'>{new Date(post.createdAt).toLocaleString()}</span>
           </div>
         </div>
         <Dialog>
           <DialogTrigger asChild>
-            <Button variant='ghost' size='icon' className='h-9 w-9 rounded-2xl border border-slate-800/60 bg-slate-900/70 hover:bg-slate-900/90'>
+            <Button variant='ghost' size='icon' className='h-9 w-9 rounded-2xl border border-[rgba(0,0,0,0.05)] bg-white/80 hover:bg-white'>
               <MoreHorizontal className='h-4 w-4' />
             </Button>
           </DialogTrigger>
-          <DialogContent className='flex max-w-sm flex-col items-stretch gap-2 border border-slate-800/80 bg-slate-900/80 text-sm text-slate-100'>
-            {post?.author?._id !== user?._id && <Button variant='ghost' className='w-full justify-start text-rose-400 hover:text-rose-300'>Unfollow</Button>}
-            <Button variant='ghost' className='w-full justify-start'>Add to favorites</Button>
-            {user && user?._id === post?.author._id && <Button onClick={deletePostHandler} variant='ghost' className='w-full justify-start text-emerald-300 hover:text-emerald-200'>Delete</Button>}
+          <DialogContent className='flex max-w-sm flex-col items-stretch gap-2 border border-[rgba(0,0,0,0.08)] bg-white/90 text-sm text-[#4a4a4a] shadow-[0_20px_60px_-48px_rgba(51,51,51,0.55)]'>
+            {post?.author?._id !== user?._id && <Button variant='ghost' className='w-full justify-start text-[#c76b6b] hover:text-[#b25a5a]'>Unfollow</Button>}
+            <Button variant='ghost' className='w-full justify-start text-[#4a4a4a] hover:text-[#333333]'>Add to favorites</Button>
+            {user && user?._id === post?.author._id && <Button onClick={deletePostHandler} variant='ghost' className='w-full justify-start text-[#5a8a6b] hover:text-[#4a785c]'>Delete</Button>}
           </DialogContent>
         </Dialog>
       </div>
-      <div className='relative bg-slate-950/60'>
+      <div className='relative bg-[#f6f6f6]'>
         <img
           className='aspect-square w-full rounded-[2rem] object-cover'
           src={post.image}
           alt='post_img'
         />
-        <div className='pointer-events-none absolute inset-x-0 bottom-0 h-24 bg-gradient-to-t from-slate-950/80 via-slate-950/0 to-transparent' />
+        <div className='pointer-events-none absolute inset-x-0 bottom-0 h-24 bg-gradient-to-t from-black/40 via-transparent to-transparent' />
       </div>
 
       <div className='space-y-4 px-6 py-5'>
         <div className='flex items-center justify-between'>
           <div className='flex items-center gap-3'>
             {liked
-              ? <FaHeart onClick={likeOrDislikeHandler} size={24} className='cursor-pointer text-rose-400 drop-shadow-[0_0_12px_rgba(251,113,133,0.4)]' />
-              : <FaRegHeart onClick={likeOrDislikeHandler} size={22} className='cursor-pointer text-slate-300 transition hover:text-slate-100' />}
+              ? <FaHeart onClick={likeOrDislikeHandler} size={24} className='cursor-pointer text-[#d66c6c] drop-shadow-[0_0_12px_rgba(214,108,108,0.4)]' />
+              : <FaRegHeart onClick={likeOrDislikeHandler} size={22} className='cursor-pointer text-[#b8b8b8] transition hover:text-[#d5b69d]' />}
 
             <MessageCircle
               onClick={() => {
                 dispatch(setSelectedPost(post))
                 setOpen(true)
               }}
-              className='h-5 w-5 cursor-pointer text-slate-300 transition hover:text-slate-100'
+              className='h-5 w-5 cursor-pointer text-[#b8b8b8] transition hover:text-[#d5b69d]'
             />
-            <Send className='h-5 w-5 cursor-pointer text-slate-300 transition hover:text-slate-100' />
+            <Send className='h-5 w-5 cursor-pointer text-[#b8b8b8] transition hover:text-[#d5b69d]' />
           </div>
-          <Bookmark onClick={bookmarkHandler} className='h-5 w-5 cursor-pointer text-slate-300 transition hover:text-slate-100' />
+          <Bookmark onClick={bookmarkHandler} className='h-5 w-5 cursor-pointer text-[#b8b8b8] transition hover:text-[#d5b69d]' />
         </div>
-        <div className='space-y-2 text-sm text-slate-200'>
-          <span className='font-medium text-sky-200'>{postLike} appreciations</span>
+        <div className='space-y-2 text-sm text-[#4a4a4a]'>
+          <span className='font-medium text-[#c8a9f1]'>{postLike} appreciations</span>
           <p className='leading-6'>
-            <span className='mr-2 font-semibold text-slate-100'>{post.author?.username}</span>
+            <span className='mr-2 font-semibold text-[#333333]'>{post.author?.username}</span>
             {post.caption}
           </p>
           {comment.length > 0 && (
@@ -174,22 +174,22 @@ const Post = ({ post }) => {
                 dispatch(setSelectedPost(post))
                 setOpen(true)
               }}
-              className='text-xs text-slate-400 transition hover:text-slate-200'
+              className='text-xs text-[#8c8c8c] transition hover:text-[#4a4a4a]'
             >
               View all {comment.length} responses
             </button>
           )}
         </div>
         <CommentDialog open={open} setOpen={setOpen} />
-        <div className='flex items-center gap-3 rounded-2xl border border-slate-800/70 bg-slate-950/50 px-4 py-2'>
+        <div className='flex items-center gap-3 rounded-2xl border border-[rgba(0,0,0,0.06)] bg-white/70 px-4 py-2'>
           <input
             type='text'
             placeholder='Add a thoughtful response...'
             value={text}
             onChange={changeEventHandler}
-            className='w-full bg-transparent text-sm text-slate-100 placeholder:text-slate-500 focus:outline-none'
+            className='w-full bg-transparent text-sm text-[#333333] placeholder:text-[#b8b8b8] focus:outline-none'
           />
-          {text && <button onClick={commentHandler} className='text-sm font-semibold text-sky-300 transition hover:text-sky-200'>Post</button>}
+          {text && <button onClick={commentHandler} className='text-sm font-semibold text-[#c8a9f1] transition hover:text-[#b897e9]'>Post</button>}
         </div>
       </div>
     </div>

--- a/frontend/src/components/Post.jsx
+++ b/frontend/src/components/Post.jsx
@@ -1,9 +1,9 @@
-import React, { useState } from 'react'
+import { useState } from 'react'
 import { Avatar, AvatarFallback, AvatarImage } from './ui/avatar'
 import { Dialog, DialogContent, DialogTrigger } from './ui/dialog'
 import { Bookmark, MessageCircle, MoreHorizontal, Send } from 'lucide-react'
 import { Button } from './ui/button'
-import { FaHeart, FaRegHeart } from "react-icons/fa";
+import { FaHeart, FaRegHeart } from 'react-icons/fa'
 import CommentDialog from './CommentDialog'
 import { useDispatch, useSelector } from 'react-redux'
 import axios from 'axios'
@@ -12,178 +12,188 @@ import { setPosts, setSelectedPost } from '@/redux/postSlice'
 import { Badge } from './ui/badge'
 
 const Post = ({ post }) => {
-    const [text, setText] = useState("");
-    const [open, setOpen] = useState(false);
-    const { user } = useSelector(store => store.auth);
-    const { posts } = useSelector(store => store.post);
-    const [liked, setLiked] = useState(post.likes.includes(user?._id) || false);
-    const [postLike, setPostLike] = useState(post.likes.length);
-    const [comment, setComment] = useState(post.comments);
-    const dispatch = useDispatch();
+  const [text, setText] = useState('')
+  const [open, setOpen] = useState(false)
+  const { user } = useSelector(store => store.auth)
+  const { posts } = useSelector(store => store.post)
+  const [liked, setLiked] = useState(post.likes.includes(user?._id) || false)
+  const [postLike, setPostLike] = useState(post.likes.length)
+  const [comment, setComment] = useState(post.comments)
+  const dispatch = useDispatch()
 
-    const changeEventHandler = (e) => {
-        const inputText = e.target.value;
-        if (inputText.trim()) {
-            setText(inputText);
-        } else {
-            setText("");
-        }
+  const changeEventHandler = (e) => {
+    const inputText = e.target.value
+    if (inputText.trim()) {
+      setText(inputText)
+    } else {
+      setText('')
     }
+  }
 
-    const likeOrDislikeHandler = async () => {
-        try {
-            const action = liked ? 'dislike' : 'like';
-            const res = await axios.get(`https://let-s-talk-lq7h.onrender.com/api/v1/post/${post._id}/${action}`, { withCredentials: true });
-            console.log(res.data);
-            if (res.data.success) {
-                const updatedLikes = liked ? postLike - 1 : postLike + 1;
-                setPostLike(updatedLikes);
-                setLiked(!liked);
+  const likeOrDislikeHandler = async () => {
+    try {
+      const action = liked ? 'dislike' : 'like'
+      const res = await axios.get(`https://let-s-talk-lq7h.onrender.com/api/v1/post/${post._id}/${action}`, { withCredentials: true })
+      if (res.data.success) {
+        const updatedLikes = liked ? postLike - 1 : postLike + 1
+        setPostLike(updatedLikes)
+        setLiked(!liked)
 
-                // apne post ko update krunga
-                const updatedPostData = posts.map(p =>
-                    p._id === post._id ? {
-                        ...p,
-                        likes: liked ? p.likes.filter(id => id !== user._id) : [...p.likes, user._id]
-                    } : p
-                );
-                dispatch(setPosts(updatedPostData));
-                toast.success(res.data.message);
-            }
-        } catch (error) {
-            console.log(error);
-        }
+        const updatedPostData = posts.map(p =>
+          p._id === post._id ? {
+            ...p,
+            likes: liked ? p.likes.filter(id => id !== user._id) : [...p.likes, user._id]
+          } : p
+        )
+        dispatch(setPosts(updatedPostData))
+        toast.success(res.data.message)
+      }
+    } catch (error) {
+      console.log(error)
     }
+  }
 
-    const commentHandler = async () => {
+  const commentHandler = async () => {
+    try {
+      const res = await axios.post(`https://let-s-talk-lq7h.onrender.com/api/v1/post/${post._id}/comment`, { text }, {
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        withCredentials: true
+      })
+      if (res.data.success) {
+        const updatedCommentData = [...comment, res.data.comment]
+        setComment(updatedCommentData)
 
-        try {
-            const res = await axios.post(`https://let-s-talk-lq7h.onrender.com/api/v1/post/${post._id}/comment`, { text }, {
-                headers: {
-                    'Content-Type': 'application/json'
-                },
-                withCredentials: true
-            });
-            console.log(res.data);
-            if (res.data.success) {
-                const updatedCommentData = [...comment, res.data.comment];
-                setComment(updatedCommentData);
+        const updatedPostData = posts.map(p =>
+          p._id === post._id ? { ...p, comments: updatedCommentData } : p
+        )
 
-                const updatedPostData = posts.map(p =>
-                    p._id === post._id ? { ...p, comments: updatedCommentData } : p
-                );
-
-                dispatch(setPosts(updatedPostData));
-                toast.success(res.data.message);
-                setText("");
-            }
-        } catch (error) {
-            console.log(error);
-        }
+        dispatch(setPosts(updatedPostData))
+        toast.success(res.data.message)
+        setText('')
+      }
+    } catch (error) {
+      console.log(error)
     }
+  }
 
-    const deletePostHandler = async () => {
-        try {
-            const res = await axios.delete(`https://let-s-talk-lq7h.onrender.com/api/v1/post/delete/${post?._id}`, { withCredentials: true })
-            if (res.data.success) {
-                const updatedPostData = posts.filter((postItem) => postItem?._id !== post?._id);
-                dispatch(setPosts(updatedPostData));
-                toast.success(res.data.message);
-            }
-        } catch (error) {
-            console.log(error);
-            toast.error(error.response.data.messsage);
-        }
+  const deletePostHandler = async () => {
+    try {
+      const res = await axios.delete(`https://let-s-talk-lq7h.onrender.com/api/v1/post/delete/${post?._id}`, { withCredentials: true })
+      if (res.data.success) {
+        const updatedPostData = posts.filter((postItem) => postItem?._id !== post?._id)
+        dispatch(setPosts(updatedPostData))
+        toast.success(res.data.message)
+      }
+    } catch (error) {
+      console.log(error)
+      toast.error(error.response?.data?.message || 'Unable to remove post right now')
     }
+  }
 
-    const bookmarkHandler = async () => {
-        try {
-            const res = await axios.get(`https://let-s-talk-lq7h.onrender.com/api/v1/post/${post?._id}/bookmark`, {withCredentials:true});
-            if(res.data.success){
-                toast.success(res.data.message);
-            }
-        } catch (error) {
-            console.log(error);
-        }
+  const bookmarkHandler = async () => {
+    try {
+      const res = await axios.get(`https://let-s-talk-lq7h.onrender.com/api/v1/post/${post?._id}/bookmark`, { withCredentials: true })
+      if (res.data.success) {
+        toast.success(res.data.message)
+      }
+    } catch (error) {
+      console.log(error)
     }
-    return (
-        <div className='my-8 w-full max-w-sm mx-auto'>
-            <div className='flex items-center justify-between'>
-                <div className='flex items-center gap-2'>
-                    <Avatar>
-                        <AvatarImage src={post.author?.profilePicture} alt="post_image" />
-                        <AvatarFallback>CN</AvatarFallback>
-                    </Avatar>
-                    <div className='flex items-center gap-3'>
-                        <h1>{post.author?.username}</h1>
-                       {user?._id === post.author._id &&  <Badge variant="secondary">Author</Badge>}
-                    </div>
-                </div>
-                <Dialog>
-                    <DialogTrigger asChild>
-                        <MoreHorizontal className='cursor-pointer' />
-                    </DialogTrigger>
-                    <DialogContent className="flex flex-col items-center text-sm text-center">
-                        {
-                        post?.author?._id !== user?._id && <Button variant='ghost' className="cursor-pointer w-fit text-[#ED4956] font-bold">Unfollow</Button>
-                        }
-                        
-                        <Button variant='ghost' className="cursor-pointer w-fit">Add to favorites</Button>
-                        {
-                            user && user?._id === post?.author._id && <Button onClick={deletePostHandler} variant='ghost' className="cursor-pointer w-fit">Delete</Button>
-                        }
-                    </DialogContent>
-                </Dialog>
+  }
+
+  return (
+    <div className='w-full overflow-hidden rounded-[2.25rem] border border-slate-800/60 bg-slate-900/70 shadow-xl shadow-sky-500/10 backdrop-blur-xl'>
+      <div className='flex items-center justify-between gap-4 px-6 pb-4 pt-6'>
+        <div className='flex items-center gap-3'>
+          <div className='rounded-3xl bg-gradient-to-br from-sky-500/40 via-emerald-400/30 to-indigo-500/20 p-[2px]'>
+            <Avatar className='h-12 w-12 border border-slate-900'>
+              <AvatarImage src={post.author?.profilePicture} alt='post_image' />
+              <AvatarFallback>CN</AvatarFallback>
+            </Avatar>
+          </div>
+          <div className='flex flex-col'>
+            <div className='flex items-center gap-3'>
+              <h1 className='text-sm font-semibold text-slate-100'>{post.author?.username}</h1>
+              {user?._id === post.author._id && <Badge className='bg-slate-800/80 text-emerald-300'>Author</Badge>}
             </div>
-            <img
-                className='rounded-sm my-2 w-full aspect-square object-cover'
-                src={post.image}
-                alt="post_img"
-            />
-
-            <div className='flex items-center justify-between my-2'>
-                <div className='flex items-center gap-3'>
-                    {
-                        liked ? <FaHeart onClick={likeOrDislikeHandler} size={'24'} className='cursor-pointer text-red-600' /> : <FaRegHeart onClick={likeOrDislikeHandler} size={'22px'} className='cursor-pointer hover:text-gray-600' />
-                    }
-
-                    <MessageCircle onClick={() => {
-                        dispatch(setSelectedPost(post));
-                        setOpen(true);
-                    }} className='cursor-pointer hover:text-gray-600' />
-                    <Send className='cursor-pointer hover:text-gray-600' />
-                </div>
-                <Bookmark onClick={bookmarkHandler} className='cursor-pointer hover:text-gray-600' />
-            </div>
-            <span className='font-medium block mb-2'>{postLike} likes</span>
-            <p>
-                <span className='font-medium mr-2'>{post.author?.username}</span>
-                {post.caption}
-            </p>
-            {
-                comment.length > 0 && (
-                    <span onClick={() => {
-                        dispatch(setSelectedPost(post));
-                        setOpen(true);
-                    }} className='cursor-pointer text-sm text-gray-400'>View all {comment.length} comments</span>
-                )
-            }
-            <CommentDialog open={open} setOpen={setOpen} />
-            <div className='flex items-center justify-between'>
-                <input
-                    type="text"
-                    placeholder='Add a comment...'
-                    value={text}
-                    onChange={changeEventHandler}
-                    className='outline-none text-sm w-full'
-                />
-                {
-                    text && <span onClick={commentHandler} className='text-[#3BADF8] cursor-pointer'>Post</span>
-                }
-
-            </div>
+            <span className='text-xs text-slate-500'>{new Date(post.createdAt).toLocaleString()}</span>
+          </div>
         </div>
-    )
+        <Dialog>
+          <DialogTrigger asChild>
+            <Button variant='ghost' size='icon' className='h-9 w-9 rounded-2xl border border-slate-800/60 bg-slate-900/70 hover:bg-slate-900/90'>
+              <MoreHorizontal className='h-4 w-4' />
+            </Button>
+          </DialogTrigger>
+          <DialogContent className='flex max-w-sm flex-col items-stretch gap-2 border border-slate-800/80 bg-slate-900/80 text-sm text-slate-100'>
+            {post?.author?._id !== user?._id && <Button variant='ghost' className='w-full justify-start text-rose-400 hover:text-rose-300'>Unfollow</Button>}
+            <Button variant='ghost' className='w-full justify-start'>Add to favorites</Button>
+            {user && user?._id === post?.author._id && <Button onClick={deletePostHandler} variant='ghost' className='w-full justify-start text-emerald-300 hover:text-emerald-200'>Delete</Button>}
+          </DialogContent>
+        </Dialog>
+      </div>
+      <div className='relative bg-slate-950/60'>
+        <img
+          className='aspect-square w-full rounded-[2rem] object-cover'
+          src={post.image}
+          alt='post_img'
+        />
+        <div className='pointer-events-none absolute inset-x-0 bottom-0 h-24 bg-gradient-to-t from-slate-950/80 via-slate-950/0 to-transparent' />
+      </div>
+
+      <div className='space-y-4 px-6 py-5'>
+        <div className='flex items-center justify-between'>
+          <div className='flex items-center gap-3'>
+            {liked
+              ? <FaHeart onClick={likeOrDislikeHandler} size={24} className='cursor-pointer text-rose-400 drop-shadow-[0_0_12px_rgba(251,113,133,0.4)]' />
+              : <FaRegHeart onClick={likeOrDislikeHandler} size={22} className='cursor-pointer text-slate-300 transition hover:text-slate-100' />}
+
+            <MessageCircle
+              onClick={() => {
+                dispatch(setSelectedPost(post))
+                setOpen(true)
+              }}
+              className='h-5 w-5 cursor-pointer text-slate-300 transition hover:text-slate-100'
+            />
+            <Send className='h-5 w-5 cursor-pointer text-slate-300 transition hover:text-slate-100' />
+          </div>
+          <Bookmark onClick={bookmarkHandler} className='h-5 w-5 cursor-pointer text-slate-300 transition hover:text-slate-100' />
+        </div>
+        <div className='space-y-2 text-sm text-slate-200'>
+          <span className='font-medium text-sky-200'>{postLike} appreciations</span>
+          <p className='leading-6'>
+            <span className='mr-2 font-semibold text-slate-100'>{post.author?.username}</span>
+            {post.caption}
+          </p>
+          {comment.length > 0 && (
+            <button
+              type='button'
+              onClick={() => {
+                dispatch(setSelectedPost(post))
+                setOpen(true)
+              }}
+              className='text-xs text-slate-400 transition hover:text-slate-200'
+            >
+              View all {comment.length} responses
+            </button>
+          )}
+        </div>
+        <CommentDialog open={open} setOpen={setOpen} />
+        <div className='flex items-center gap-3 rounded-2xl border border-slate-800/70 bg-slate-950/50 px-4 py-2'>
+          <input
+            type='text'
+            placeholder='Add a thoughtful response...'
+            value={text}
+            onChange={changeEventHandler}
+            className='w-full bg-transparent text-sm text-slate-100 placeholder:text-slate-500 focus:outline-none'
+          />
+          {text && <button onClick={commentHandler} className='text-sm font-semibold text-sky-300 transition hover:text-sky-200'>Post</button>}
+        </div>
+      </div>
+    </div>
+  )
 }
 
 export default Post

--- a/frontend/src/components/Post.jsx
+++ b/frontend/src/components/Post.jsx
@@ -104,39 +104,37 @@ const Post = ({ post }) => {
   }
 
   return (
-    <div className='w-full overflow-hidden rounded-[2.25rem] border border-[rgba(0,0,0,0.05)] bg-white/85 shadow-[0_30px_80px_-60px_rgba(51,51,51,0.65)] backdrop-blur-xl'>
-      <div className='flex items-center justify-between gap-4 px-6 pb-4 pt-6'>
+    <div className='w-full overflow-hidden rounded-xl border border-[var(--color-outline)] bg-[var(--color-surface-raised)] shadow-[0_20px_40px_rgba(0,0,0,0.08)]'>
+      <div className='flex items-center justify-between gap-4 border-b border-[var(--color-outline)] px-6 py-5'>
         <div className='flex items-center gap-3'>
-          <div className='rounded-3xl bg-gradient-to-br from-[#c8a9f1]/40 via-[#e8d6c6]/30 to-[#f8c8a3]/30 p-[2px]'>
-            <Avatar className='h-12 w-12 border border-[rgba(0,0,0,0.05)] bg-white'>
-              <AvatarImage src={post.author?.profilePicture} alt='post_image' />
-              <AvatarFallback>CN</AvatarFallback>
-            </Avatar>
-          </div>
+          <Avatar className='h-12 w-12 border border-[var(--color-outline)] bg-[var(--color-surface)]'>
+            <AvatarImage src={post.author?.profilePicture} alt='post_image' />
+            <AvatarFallback>CN</AvatarFallback>
+          </Avatar>
           <div className='flex flex-col'>
             <div className='flex items-center gap-3'>
-              <h1 className='text-sm font-semibold text-[#333333]'>{post.author?.username}</h1>
-              {user?._id === post.author._id && <Badge className='bg-[#f0e9ff] text-[#6f6f6f]'>Author</Badge>}
+              <h1 className='text-sm font-semibold text-[var(--color-text)]'>{post.author?.username}</h1>
+              {user?._id === post.author._id && <Badge className='bg-[var(--color-surface-muted)] text-[var(--color-text-muted)]'>Author</Badge>}
             </div>
-            <span className='text-xs text-[#8c8c8c]'>{new Date(post.createdAt).toLocaleString()}</span>
+            <span className='text-xs text-[#888888]'>{new Date(post.createdAt).toLocaleString()}</span>
           </div>
         </div>
         <Dialog>
           <DialogTrigger asChild>
-            <Button variant='ghost' size='icon' className='h-9 w-9 rounded-2xl border border-[rgba(0,0,0,0.05)] bg-white/80 hover:bg-white'>
+            <Button variant='ghost' size='icon' className='h-10 w-10 rounded-md border border-[var(--color-outline)] bg-[var(--color-surface)] hover:bg-[var(--color-surface-muted)]'>
               <MoreHorizontal className='h-4 w-4' />
             </Button>
           </DialogTrigger>
-          <DialogContent className='flex max-w-sm flex-col items-stretch gap-2 border border-[rgba(0,0,0,0.08)] bg-white/90 text-sm text-[#4a4a4a] shadow-[0_20px_60px_-48px_rgba(51,51,51,0.55)]'>
+          <DialogContent className='flex max-w-sm flex-col items-stretch gap-2 border border-[var(--color-outline)] bg-[var(--color-surface-raised)] text-sm text-[var(--color-text-muted)] shadow-[0_16px_44px_rgba(0,0,0,0.12)]'>
             {post?.author?._id !== user?._id && <Button variant='ghost' className='w-full justify-start text-[#c76b6b] hover:text-[#b25a5a]'>Unfollow</Button>}
-            <Button variant='ghost' className='w-full justify-start text-[#4a4a4a] hover:text-[#333333]'>Add to favorites</Button>
-            {user && user?._id === post?.author._id && <Button onClick={deletePostHandler} variant='ghost' className='w-full justify-start text-[#5a8a6b] hover:text-[#4a785c]'>Delete</Button>}
+            <Button variant='ghost' className='w-full justify-start text-[var(--color-text-muted)] hover:text-[var(--color-text)]'>Add to favorites</Button>
+            {user && user?._id === post?.author._id && <Button onClick={deletePostHandler} variant='ghost' className='w-full justify-start text-[#4c8061] hover:text-[#3e6a50]'>Delete</Button>}
           </DialogContent>
         </Dialog>
       </div>
-      <div className='relative bg-[#f6f6f6]'>
+      <div className='relative bg-[var(--color-surface)]'>
         <img
-          className='aspect-square w-full rounded-[2rem] object-cover'
+          className='aspect-square w-full rounded-none object-cover'
           src={post.image}
           alt='post_img'
         />
@@ -145,26 +143,26 @@ const Post = ({ post }) => {
 
       <div className='space-y-4 px-6 py-5'>
         <div className='flex items-center justify-between'>
-          <div className='flex items-center gap-3'>
+          <div className='flex items-center gap-4 text-[var(--color-text-muted)]'>
             {liked
-              ? <FaHeart onClick={likeOrDislikeHandler} size={24} className='cursor-pointer text-[#d66c6c] drop-shadow-[0_0_12px_rgba(214,108,108,0.4)]' />
-              : <FaRegHeart onClick={likeOrDislikeHandler} size={22} className='cursor-pointer text-[#b8b8b8] transition hover:text-[#d5b69d]' />}
+              ? <FaHeart onClick={likeOrDislikeHandler} size={22} className='cursor-pointer text-[#d66c6c]' />
+              : <FaRegHeart onClick={likeOrDislikeHandler} size={22} className='cursor-pointer text-[#a5a5a5] transition hover:text-[var(--color-primary-start)]' />}
 
             <MessageCircle
               onClick={() => {
                 dispatch(setSelectedPost(post))
                 setOpen(true)
               }}
-              className='h-5 w-5 cursor-pointer text-[#b8b8b8] transition hover:text-[#d5b69d]'
+              className='h-5 w-5 cursor-pointer text-[#a5a5a5] transition hover:text-[var(--color-primary-start)]'
             />
-            <Send className='h-5 w-5 cursor-pointer text-[#b8b8b8] transition hover:text-[#d5b69d]' />
+            <Send className='h-5 w-5 cursor-pointer text-[#a5a5a5] transition hover:text-[var(--color-primary-start)]' />
           </div>
-          <Bookmark onClick={bookmarkHandler} className='h-5 w-5 cursor-pointer text-[#b8b8b8] transition hover:text-[#d5b69d]' />
+          <Bookmark onClick={bookmarkHandler} className='h-5 w-5 cursor-pointer text-[#a5a5a5] transition hover:text-[var(--color-primary-start)]' />
         </div>
-        <div className='space-y-2 text-sm text-[#4a4a4a]'>
-          <span className='font-medium text-[#c8a9f1]'>{postLike} appreciations</span>
+        <div className='space-y-2 text-sm text-[var(--color-text-muted)]'>
+          <span className='font-semibold text-[var(--color-primary-start)]'>{postLike} appreciations</span>
           <p className='leading-6'>
-            <span className='mr-2 font-semibold text-[#333333]'>{post.author?.username}</span>
+            <span className='mr-2 font-semibold text-[var(--color-text)]'>{post.author?.username}</span>
             {post.caption}
           </p>
           {comment.length > 0 && (
@@ -174,22 +172,22 @@ const Post = ({ post }) => {
                 dispatch(setSelectedPost(post))
                 setOpen(true)
               }}
-              className='text-xs text-[#8c8c8c] transition hover:text-[#4a4a4a]'
+              className='text-xs text-[#7c7c7c] transition hover:text-[var(--color-text)]'
             >
               View all {comment.length} responses
             </button>
           )}
         </div>
         <CommentDialog open={open} setOpen={setOpen} />
-        <div className='flex items-center gap-3 rounded-2xl border border-[rgba(0,0,0,0.06)] bg-white/70 px-4 py-2'>
+        <div className='flex items-center gap-3 rounded-lg border border-[var(--color-outline)] bg-[var(--color-surface)] px-4 py-3'>
           <input
             type='text'
             placeholder='Add a thoughtful response...'
             value={text}
             onChange={changeEventHandler}
-            className='w-full bg-transparent text-sm text-[#333333] placeholder:text-[#b8b8b8] focus:outline-none'
+            className='w-full bg-transparent text-sm text-[var(--color-text)] placeholder:text-[#a0a0a0] focus:outline-none'
           />
-          {text && <button onClick={commentHandler} className='text-sm font-semibold text-[#c8a9f1] transition hover:text-[#b897e9]'>Post</button>}
+          {text && <button onClick={commentHandler} className='text-sm font-semibold text-[var(--color-primary-start)] transition hover:text-[#b897e9]'>Post</button>}
         </div>
       </div>
     </div>

--- a/frontend/src/components/PostDetail.jsx
+++ b/frontend/src/components/PostDetail.jsx
@@ -1,0 +1,72 @@
+import { useEffect } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { useNavigate, useParams } from 'react-router-dom'
+import { ArrowLeft, Compass } from 'lucide-react'
+import useGetAllPost from '@/hooks/useGetAllPost'
+import { Button } from './ui/button'
+import Post from './Post'
+import { setSelectedPost } from '@/redux/postSlice'
+
+const PostDetail = () => {
+  const { id } = useParams()
+  const navigate = useNavigate()
+  useGetAllPost()
+  const dispatch = useDispatch()
+  const { posts } = useSelector(store => store.post)
+
+  const post = posts.find(item => item._id === id)
+
+  useEffect(() => {
+    if (post) {
+      dispatch(setSelectedPost(post))
+      window.scrollTo({ top: 0, behavior: 'smooth' })
+    }
+  }, [dispatch, post])
+
+  const goBack = () => {
+    if (window.history.length > 1) {
+      navigate(-1)
+    } else {
+      navigate('/')
+    }
+  }
+
+  return (
+    <div className='mx-auto flex w-full max-w-4xl flex-col gap-6 rounded-[2.5rem] border border-slate-800/60 bg-slate-900/70 p-6 shadow-xl shadow-sky-500/10 backdrop-blur-xl'>
+      <div className='flex items-center justify-between gap-4'>
+        <Button
+          variant='ghost'
+          onClick={goBack}
+          className='flex items-center gap-2 rounded-full border border-slate-800/70 bg-slate-950/50 px-4 text-sm text-slate-200 hover:bg-slate-900/70'
+        >
+          <ArrowLeft className='h-4 w-4' />
+          Back
+        </Button>
+        <Button
+          variant='ghost'
+          className='flex items-center gap-2 rounded-full border border-slate-800/70 bg-slate-950/50 px-4 text-sm text-slate-200 hover:bg-slate-900/70'
+          onClick={() => navigate('/explore')}
+        >
+          <Compass className='h-4 w-4 text-sky-300' />
+          Explore more
+        </Button>
+      </div>
+
+      {!posts.length && (
+        <div className='rounded-3xl border border-slate-800/60 bg-slate-950/60 p-10 text-center text-sm text-slate-400'>
+          Fetching the latest vibes for you...
+        </div>
+      )}
+
+      {posts.length > 0 && !post && (
+        <div className='rounded-3xl border border-slate-800/60 bg-slate-950/60 p-10 text-center text-sm text-slate-400'>
+          This post is no longer available. Discover new stories in Explore!
+        </div>
+      )}
+
+      {post && <Post post={post} />}
+    </div>
+  )
+}
+
+export default PostDetail

--- a/frontend/src/components/PostDetail.jsx
+++ b/frontend/src/components/PostDetail.jsx
@@ -32,34 +32,34 @@ const PostDetail = () => {
   }
 
   return (
-    <div className='mx-auto flex w-full max-w-4xl flex-col gap-6 rounded-[2.5rem] border border-slate-800/60 bg-slate-900/70 p-6 shadow-xl shadow-sky-500/10 backdrop-blur-xl'>
+    <div className='mx-auto flex w-full max-w-4xl flex-col gap-6 rounded-[2.5rem] border border-[rgba(0,0,0,0.05)] bg-white/80 p-6 text-[#4a4a4a] shadow-[0_30px_80px_-60px_rgba(51,51,51,0.55)] backdrop-blur-xl'>
       <div className='flex items-center justify-between gap-4'>
         <Button
-          variant='ghost'
+          variant='outline'
           onClick={goBack}
-          className='flex items-center gap-2 rounded-full border border-slate-800/70 bg-slate-950/50 px-4 text-sm text-slate-200 hover:bg-slate-900/70'
+          className='flex items-center gap-2 rounded-full border border-[rgba(0,0,0,0.08)] bg-white/80 px-4 text-sm text-[#4a4a4a] hover:bg-white'
         >
           <ArrowLeft className='h-4 w-4' />
           Back
         </Button>
         <Button
-          variant='ghost'
-          className='flex items-center gap-2 rounded-full border border-slate-800/70 bg-slate-950/50 px-4 text-sm text-slate-200 hover:bg-slate-900/70'
+          variant='outline'
+          className='flex items-center gap-2 rounded-full border border-[rgba(0,0,0,0.08)] bg-white/80 px-4 text-sm text-[#4a4a4a] hover:bg-white'
           onClick={() => navigate('/explore')}
         >
-          <Compass className='h-4 w-4 text-sky-300' />
+          <Compass className='h-4 w-4 text-[#c8a9f1]' />
           Explore more
         </Button>
       </div>
 
       {!posts.length && (
-        <div className='rounded-3xl border border-slate-800/60 bg-slate-950/60 p-10 text-center text-sm text-slate-400'>
+        <div className='rounded-3xl border border-[rgba(0,0,0,0.05)] bg-white/70 p-10 text-center text-sm text-[#6f6f6f]'>
           Fetching the latest vibes for you...
         </div>
       )}
 
       {posts.length > 0 && !post && (
-        <div className='rounded-3xl border border-slate-800/60 bg-slate-950/60 p-10 text-center text-sm text-slate-400'>
+        <div className='rounded-3xl border border-[rgba(0,0,0,0.05)] bg-white/70 p-10 text-center text-sm text-[#6f6f6f]'>
           This post is no longer available. Discover new stories in Explore!
         </div>
       )}

--- a/frontend/src/components/Posts.jsx
+++ b/frontend/src/components/Posts.jsx
@@ -1,14 +1,11 @@
-import React from 'react'
 import Post from './Post'
 import { useSelector } from 'react-redux'
 
 const Posts = () => {
-  const {posts} = useSelector(store=>store.post);
+  const { posts } = useSelector(store => store.post)
   return (
-    <div>
-        {
-            posts.map((post) => <Post key={post._id} post={post}/>)
-        }
+    <div className='flex flex-col gap-6'>
+      {posts.map((post) => <Post key={post._id} post={post} />)}
     </div>
   )
 }

--- a/frontend/src/components/Profile.jsx
+++ b/frontend/src/components/Profile.jsx
@@ -1,36 +1,84 @@
 import React, { useEffect, useMemo, useState } from 'react'
 import { Avatar, AvatarFallback, AvatarImage } from './ui/avatar'
-import useGetUserProfile from '@/hooks/useGetUserProfile';
-import { Link, useParams } from 'react-router-dom';
-import { useSelector } from 'react-redux';
-import { Button } from './ui/button';
-import { Badge } from './ui/badge';
-import { AtSign, Heart, MessageCircle } from 'lucide-react';
-import axios from 'axios';
-import { toast } from 'sonner';
+import useGetUserProfile from '@/hooks/useGetUserProfile'
+import useReels from '@/hooks/useReels'
+import useGetAllPost from '@/hooks/useGetAllPost'
+import { Link, useParams } from 'react-router-dom'
+import { useSelector } from 'react-redux'
+import { Button } from './ui/button'
+import { Badge } from './ui/badge'
+import { AtSign, Heart, MessageCircle } from 'lucide-react'
+import axios from 'axios'
+import { toast } from 'sonner'
 
 const Profile = () => {
-  const params = useParams();
-  const userId = params.id;
-  const { refetch } = useGetUserProfile(userId);
-  const [activeTab, setActiveTab] = useState('posts');
+  useReels()
+  useGetAllPost()
+
+  const params = useParams()
+  const userId = params.id
+  const { refetch } = useGetUserProfile(userId)
+  const [activeTab, setActiveTab] = useState('posts')
 
   useEffect(() => {
-    setActiveTab('posts');
-  }, [userId]);
+    setActiveTab('posts')
+  }, [userId])
 
-  const { userProfile, user, userProfileMeta } = useSelector(store => store.auth);
+  const { userProfile, user, userProfileMeta } = useSelector(store => store.auth)
+  const { reels } = useSelector(store => store.reel)
+  const { posts: feedPosts } = useSelector(store => store.post)
 
-  const isLoggedInUserProfile = user?._id === userProfile?._id;
-  const isFollowing = userProfileMeta?.isFollowing;
-  const hasPendingRequest = userProfileMeta?.hasPendingRequest;
-  const canViewProfile = userProfileMeta?.canViewFullProfile || isLoggedInUserProfile;
+  const isLoggedInUserProfile = user?._id === userProfile?._id
+  const isFollowing = userProfileMeta?.isFollowing
+  const hasPendingRequest = userProfileMeta?.hasPendingRequest
+  const canViewProfile = userProfileMeta?.canViewFullProfile || isLoggedInUserProfile
+
+  const profileId = userProfile?._id
 
   const handleTabChange = (tab) => {
-    setActiveTab(tab);
+    setActiveTab(tab)
   }
 
-  const displayedPost = activeTab === 'posts' ? userProfile?.posts : userProfile?.bookmarks;
+  const profilePosts = canViewProfile ? userProfile?.posts || [] : []
+  const savedPosts = isLoggedInUserProfile ? userProfile?.bookmarks || [] : []
+  const profileReels = useMemo(() => {
+    if (!canViewProfile) return []
+    return reels.filter(reel => reel.author?._id === profileId)
+  }, [canViewProfile, profileId, reels])
+
+  const taggedPosts = useMemo(() => {
+    if (!canViewProfile) return []
+    const username = userProfile?.username?.toLowerCase()
+    if (!username) return []
+    const handle = `@${username}`
+    return feedPosts.filter(post => (post?.caption || '').toLowerCase().includes(handle))
+  }, [canViewProfile, feedPosts, userProfile?.username])
+
+  const activeCollection = useMemo(() => {
+    switch (activeTab) {
+      case 'posts':
+        return profilePosts
+      case 'saved':
+        return savedPosts
+      case 'tagged':
+        return taggedPosts
+      default:
+        return profilePosts
+    }
+  }, [activeTab, profilePosts, savedPosts, taggedPosts])
+
+  const getEmptyMessage = () => {
+    switch (activeTab) {
+      case 'saved':
+        return 'You have not saved any posts yet.'
+      case 'reels':
+        return 'No reels to show just yet.'
+      case 'tagged':
+        return 'No tagged posts yet. When friends tag you, they will appear here.'
+      default:
+        return 'No posts to display yet.'
+    }
+  }
 
   const handleFollowAction = async () => {
     try {
@@ -111,51 +159,122 @@ const Profile = () => {
             </div>
           </section>
         </div>
-        <div className='border-t border-t-gray-200'>
-          <div className='flex items-center justify-center gap-10 text-sm'>
-            <span className={`py-3 cursor-pointer ${activeTab === 'posts' ? 'font-bold' : ''}`} onClick={() => handleTabChange('posts')}>
+        <div className='border-t border-t-gray-200/20'>
+          <div className='flex flex-wrap items-center justify-center gap-6 text-xs font-semibold uppercase tracking-[0.35em] text-slate-500 sm:gap-10 sm:text-sm'>
+            <button
+              type='button'
+              onClick={() => handleTabChange('posts')}
+              className={`relative pb-4 pt-5 transition ${activeTab === 'posts' ? 'text-slate-100' : 'hover:text-slate-200'}`}
+            >
               POSTS
-            </span>
+              {activeTab === 'posts' && <span className='absolute bottom-0 left-0 right-0 mx-auto h-[2px] w-10 rounded-full bg-sky-400' />}
+            </button>
             {isLoggedInUserProfile && (
-              <span className={`py-3 cursor-pointer ${activeTab === 'saved' ? 'font-bold' : ''}`} onClick={() => handleTabChange('saved')}>
+              <button
+                type='button'
+                onClick={() => handleTabChange('saved')}
+                className={`relative pb-4 pt-5 transition ${activeTab === 'saved' ? 'text-slate-100' : 'hover:text-slate-200'}`}
+              >
                 SAVED
-              </span>
+                {activeTab === 'saved' && <span className='absolute bottom-0 left-0 right-0 mx-auto h-[2px] w-10 rounded-full bg-sky-400' />}
+              </button>
             )}
-            <span className='py-3 cursor-pointer text-gray-400'>REELS</span>
-            <span className='py-3 cursor-pointer text-gray-400'>TAGS</span>
+            <button
+              type='button'
+              onClick={() => handleTabChange('reels')}
+              className={`relative pb-4 pt-5 transition ${activeTab === 'reels' ? 'text-slate-100' : 'hover:text-slate-200'}`}
+            >
+              REELS
+              {activeTab === 'reels' && <span className='absolute bottom-0 left-0 right-0 mx-auto h-[2px] w-10 rounded-full bg-sky-400' />}
+            </button>
+            <button
+              type='button'
+              onClick={() => handleTabChange('tagged')}
+              className={`relative pb-4 pt-5 transition ${activeTab === 'tagged' ? 'text-slate-100' : 'hover:text-slate-200'}`}
+            >
+              TAGS
+              {activeTab === 'tagged' && <span className='absolute bottom-0 left-0 right-0 mx-auto h-[2px] w-10 rounded-full bg-sky-400' />}
+            </button>
           </div>
-          {
-            canViewProfile ? (
-              <div className='grid grid-cols-3 gap-1'>
-                {
-                  displayedPost?.map((post) => {
-                    return (
-                      <div key={post?._id} className='relative group cursor-pointer'>
-                        <img src={post.image} alt='postimage' className='rounded-sm my-2 w-full aspect-square object-cover' />
-                        <div className='absolute inset-0 flex items-center justify-center bg-black bg-opacity-50 opacity-0 group-hover:opacity-100 transition-opacity duration-300'>
-                          <div className='flex items-center text-white space-x-4'>
-                            <button className='flex items-center gap-2 hover:text-gray-300'>
-                              <Heart />
-                              <span>{post?.likes.length}</span>
-                            </button>
-                            <button className='flex items-center gap-2 hover:text-gray-300'>
-                              <MessageCircle />
-                              <span>{post?.comments.length}</span>
-                            </button>
+          <div className='py-6'>
+            {activeTab === 'reels' ? (
+              canViewProfile ? (
+                profileReels.length ? (
+                  <div className='grid gap-4 sm:grid-cols-2 lg:grid-cols-3'>
+                    {profileReels.map(reel => (
+                      <div
+                        key={reel._id}
+                        className='group relative overflow-hidden rounded-3xl border border-slate-800/60 bg-slate-950/40 shadow-lg shadow-violet-500/10 transition hover:border-violet-400/40 hover:shadow-violet-500/30'
+                      >
+                        <video src={reel.videoUrl} muted loop playsInline className='aspect-[9/16] w-full object-cover' />
+                        <div className='absolute inset-0 flex flex-col justify-between bg-gradient-to-t from-slate-950/80 via-transparent to-transparent p-4 opacity-0 transition group-hover:opacity-100'>
+                          <div className='flex items-center gap-3'>
+                            <Avatar className='h-9 w-9 border border-slate-900/80'>
+                              <AvatarImage src={reel.author?.profilePicture} alt={reel.author?.username} />
+                              <AvatarFallback>{reel.author?.username?.slice(0, 2)?.toUpperCase() || 'CN'}</AvatarFallback>
+                            </Avatar>
+                            <div className='flex flex-col text-left'>
+                              <span className='text-sm font-semibold text-slate-50'>{reel.caption || 'Shared a new reel'}</span>
+                              <span className='text-xs text-slate-300'>{reel.views?.length || 0} views</span>
+                            </div>
+                          </div>
+                          <div className='flex items-center gap-2 text-xs text-slate-100'>
+                            <span className='inline-flex items-center gap-1 rounded-full bg-slate-900/60 px-3 py-1'>
+                              <Heart className='h-3 w-3 text-rose-300' />
+                              {reel.likes?.length || 0}
+                            </span>
                           </div>
                         </div>
                       </div>
-                    )
-                  })
-                }
-              </div>
+                    ))}
+                  </div>
+                ) : (
+                  <div className='rounded-3xl border border-slate-800/60 bg-slate-950/40 p-10 text-center text-sm text-slate-400'>
+                    {getEmptyMessage()}
+                  </div>
+                )
+              ) : (
+                <div className='flex flex-col items-center gap-2 py-10 text-center text-sm text-gray-500'>
+                  <p>This account is private.</p>
+                  <p>Send a follow request to see their posts.</p>
+                </div>
+              )
+            ) : canViewProfile || (activeTab === 'saved' && isLoggedInUserProfile) ? (
+              activeCollection.length ? (
+                <div className='grid grid-cols-2 gap-3 sm:grid-cols-3 sm:gap-4'>
+                  {activeCollection.map(post => (
+                    <div
+                      key={post?._id}
+                      className='group relative overflow-hidden rounded-3xl border border-slate-800/60 bg-slate-950/40 shadow-inner shadow-slate-950/60'
+                    >
+                      <img src={post.image} alt='postimage' className='aspect-square w-full object-cover transition duration-300 group-hover:scale-105' />
+                      <div className='absolute inset-0 flex items-center justify-center bg-slate-950/60 opacity-0 transition-opacity duration-300 group-hover:opacity-100'>
+                        <div className='flex items-center gap-6 text-sm font-semibold text-slate-100'>
+                          <span className='flex items-center gap-2'>
+                            <Heart className='h-4 w-4 text-rose-300' />
+                            {post?.likes?.length || 0}
+                          </span>
+                          <span className='flex items-center gap-2'>
+                            <MessageCircle className='h-4 w-4 text-sky-300' />
+                            {post?.comments?.length || 0}
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <div className='rounded-3xl border border-slate-800/60 bg-slate-950/40 p-10 text-center text-sm text-slate-400'>
+                  {getEmptyMessage()}
+                </div>
+              )
             ) : (
               <div className='flex flex-col items-center gap-2 py-10 text-center text-sm text-gray-500'>
                 <p>This account is private.</p>
                 <p>Send a follow request to see their posts.</p>
               </div>
-            )
-          }
+            )}
+          </div>
         </div>
       </div>
     </div>

--- a/frontend/src/components/Profile.jsx
+++ b/frontend/src/components/Profile.jsx
@@ -82,75 +82,76 @@ const Profile = () => {
 
   const handleFollowAction = async () => {
     try {
-      const res = await axios.post(`https://let-s-talk-lq7h.onrender.com/api/v1/user/followorunfollow/${userId}`, {}, { withCredentials: true });
-      if(res.data.success){
-        toast.success(res.data.message);
-        await refetch();
+      const res = await axios.post(`https://let-s-talk-lq7h.onrender.com/api/v1/user/followorunfollow/${userId}`, {}, { withCredentials: true })
+      if (res.data.success) {
+        toast.success(res.data.message)
+        await refetch()
       }
     } catch (error) {
-      console.log(error);
-      toast.error(error?.response?.data?.message || 'Something went wrong');
+      console.log(error)
+      toast.error(error?.response?.data?.message || 'Something went wrong')
     }
-  };
+  }
 
   const followButtonLabel = useMemo(() => {
-    if(isLoggedInUserProfile) return null;
-    if(isFollowing) return 'Unfollow';
-    if(hasPendingRequest) return 'Requested';
-    return 'Follow';
-  }, [isFollowing, hasPendingRequest, isLoggedInUserProfile]);
+    if (isLoggedInUserProfile) return null
+    if (isFollowing) return 'Unfollow'
+    if (hasPendingRequest) return 'Requested'
+    return 'Follow'
+  }, [isFollowing, hasPendingRequest, isLoggedInUserProfile])
 
   return (
-    <div className='flex max-w-5xl justify-center mx-auto pl-10'>
-      <div className='flex flex-col gap-20 p-8'>
-        <div className='grid grid-cols-2'>
+    <div className='mx-auto flex max-w-6xl justify-center px-4 py-6 text-[#4a4a4a]'>
+      <div className='flex w-full flex-col gap-12 rounded-[2.5rem] border border-[rgba(0,0,0,0.05)] bg-white/85 p-8 shadow-[0_32px_80px_-58px_rgba(51,51,51,0.5)]'>
+        <div className='grid gap-8 md:grid-cols-[240px_1fr]'>
           <section className='flex items-center justify-center'>
-            <Avatar className='h-32 w-32'>
-              <AvatarImage src={userProfile?.profilePicture} alt="profilephoto" />
+            <Avatar className='h-36 w-36 border border-[rgba(0,0,0,0.06)] bg-white shadow-[0_12px_30px_-24px_rgba(200,169,241,0.6)]'>
+              <AvatarImage src={userProfile?.profilePicture} alt='profilephoto' />
               <AvatarFallback>CN</AvatarFallback>
             </Avatar>
           </section>
           <section>
             <div className='flex flex-col gap-5'>
-              <div className='flex items-center gap-2'>
-                <span>{userProfile?.username}</span>
-                {
-                  isLoggedInUserProfile ? (
-                    <>
-                      <Link to="/account/edit"><Button variant='secondary' className='hover:bg-gray-200 h-8'>Edit profile</Button></Link>
-                      <Button variant='secondary' className='hover:bg-gray-200 h-8'>View archive</Button>
-                      <Button variant='secondary' className='hover:bg-gray-200 h-8'>Ad tools</Button>
-                    </>
-                  ) : (
-                    <>
-                      {
-                        followButtonLabel && (
-                          <Button
-                            disabled={followButtonLabel === 'Requested'}
-                            onClick={followButtonLabel === 'Requested' ? undefined : handleFollowAction}
-                            className={`h-8 ${followButtonLabel === 'Follow' ? 'bg-[#0095F6] hover:bg-[#3192d2]' : ''}`}
-                            variant={followButtonLabel === 'Unfollow' ? 'secondary' : 'default'}
-                          >
-                            {followButtonLabel}
-                          </Button>
-                        )
-                      }
-                      {isFollowing && (
-                        <Button variant='secondary' className='h-8'>Message</Button>
-                      )}
-                    </>
-                  )
-                }
+              <div className='flex flex-wrap items-center gap-3'>
+                <span className='text-xl font-semibold text-[#333333]'>{userProfile?.username}</span>
+                {isLoggedInUserProfile ? (
+                  <>
+                    <Link to='/account/edit'>
+                      <Button variant='secondary' className='h-8'>Edit profile</Button>
+                    </Link>
+                    <Button variant='secondary' className='h-8'>View archive</Button>
+                    <Button variant='secondary' className='h-8'>Ad tools</Button>
+                  </>
+                ) : (
+                  <>
+                    {followButtonLabel && (
+                      <Button
+                        disabled={followButtonLabel === 'Requested'}
+                        onClick={followButtonLabel === 'Requested' ? undefined : handleFollowAction}
+                        className={`h-8 px-5 ${followButtonLabel === 'Requested' ? 'text-[#6f6f6f]' : ''}`}
+                        variant={followButtonLabel === 'Unfollow' ? 'secondary' : followButtonLabel === 'Requested' ? 'outline' : 'default'}
+                      >
+                        {followButtonLabel}
+                      </Button>
+                    )}
+                    {isFollowing && (
+                      <Button variant='secondary' className='h-8'>Message</Button>
+                    )}
+                  </>
+                )}
               </div>
-              <div className='flex items-center gap-4'>
-                <p><span className='font-semibold'>{userProfile?.posts.length} </span>posts</p>
-                <p><span className='font-semibold'>{userProfile?.followers.length} </span>followers</p>
-                <p><span className='font-semibold'>{userProfile?.following.length} </span>following</p>
+              <div className='flex flex-wrap items-center gap-4 text-sm text-[#6f6f6f]'>
+                <p><span className='font-semibold text-[#333333]'>{userProfile?.posts.length} </span>posts</p>
+                <p><span className='font-semibold text-[#333333]'>{userProfile?.followers.length} </span>followers</p>
+                <p><span className='font-semibold text-[#333333]'>{userProfile?.following.length} </span>following</p>
               </div>
               <div className='flex flex-col gap-1'>
-                <span className='font-semibold'>{userProfile?.bio || 'bio here...'}</span>
-                <div className='flex items-center gap-2'>
-                  <Badge className='w-fit' variant='secondary'><AtSign /> <span className='pl-1'>{userProfile?.username}</span> </Badge>
+                <span className='font-semibold text-[#333333]'>{userProfile?.bio || 'bio here...'}</span>
+                <div className='flex flex-wrap items-center gap-2'>
+                  <Badge className='w-fit' variant='secondary'>
+                    <AtSign className='h-3 w-3' />
+                    <span className='pl-1'>{userProfile?.username}</span>
+                  </Badge>
                   <Badge variant={userProfile?.accountType === 'private' ? 'destructive' : 'outline'}>
                     {userProfile?.accountType === 'private' ? 'Private account' : 'Public account'}
                   </Badge>
@@ -159,41 +160,42 @@ const Profile = () => {
             </div>
           </section>
         </div>
-        <div className='border-t border-t-gray-200/20'>
-          <div className='flex flex-wrap items-center justify-center gap-6 text-xs font-semibold uppercase tracking-[0.35em] text-slate-500 sm:gap-10 sm:text-sm'>
+
+        <div className='border-t border-[rgba(0,0,0,0.06)] pt-6'>
+          <div className='flex flex-wrap items-center justify-center gap-6 text-xs font-semibold uppercase tracking-[0.35em] text-[#8c8c8c] sm:gap-10 sm:text-sm'>
             <button
               type='button'
               onClick={() => handleTabChange('posts')}
-              className={`relative pb-4 pt-5 transition ${activeTab === 'posts' ? 'text-slate-100' : 'hover:text-slate-200'}`}
+              className={`relative pb-4 pt-5 transition ${activeTab === 'posts' ? 'text-[#333333]' : 'hover:text-[#4a4a4a]'}`}
             >
               POSTS
-              {activeTab === 'posts' && <span className='absolute bottom-0 left-0 right-0 mx-auto h-[2px] w-10 rounded-full bg-sky-400' />}
+              {activeTab === 'posts' && <span className='absolute bottom-0 left-0 right-0 mx-auto h-[2px] w-10 rounded-full bg-[#c8a9f1]' />}
             </button>
             {isLoggedInUserProfile && (
               <button
                 type='button'
                 onClick={() => handleTabChange('saved')}
-                className={`relative pb-4 pt-5 transition ${activeTab === 'saved' ? 'text-slate-100' : 'hover:text-slate-200'}`}
+                className={`relative pb-4 pt-5 transition ${activeTab === 'saved' ? 'text-[#333333]' : 'hover:text-[#4a4a4a]'}`}
               >
                 SAVED
-                {activeTab === 'saved' && <span className='absolute bottom-0 left-0 right-0 mx-auto h-[2px] w-10 rounded-full bg-sky-400' />}
+                {activeTab === 'saved' && <span className='absolute bottom-0 left-0 right-0 mx-auto h-[2px] w-10 rounded-full bg-[#c8a9f1]' />}
               </button>
             )}
             <button
               type='button'
               onClick={() => handleTabChange('reels')}
-              className={`relative pb-4 pt-5 transition ${activeTab === 'reels' ? 'text-slate-100' : 'hover:text-slate-200'}`}
+              className={`relative pb-4 pt-5 transition ${activeTab === 'reels' ? 'text-[#333333]' : 'hover:text-[#4a4a4a]'}`}
             >
               REELS
-              {activeTab === 'reels' && <span className='absolute bottom-0 left-0 right-0 mx-auto h-[2px] w-10 rounded-full bg-sky-400' />}
+              {activeTab === 'reels' && <span className='absolute bottom-0 left-0 right-0 mx-auto h-[2px] w-10 rounded-full bg-[#c8a9f1]' />}
             </button>
             <button
               type='button'
               onClick={() => handleTabChange('tagged')}
-              className={`relative pb-4 pt-5 transition ${activeTab === 'tagged' ? 'text-slate-100' : 'hover:text-slate-200'}`}
+              className={`relative pb-4 pt-5 transition ${activeTab === 'tagged' ? 'text-[#333333]' : 'hover:text-[#4a4a4a]'}`}
             >
               TAGS
-              {activeTab === 'tagged' && <span className='absolute bottom-0 left-0 right-0 mx-auto h-[2px] w-10 rounded-full bg-sky-400' />}
+              {activeTab === 'tagged' && <span className='absolute bottom-0 left-0 right-0 mx-auto h-[2px] w-10 rounded-full bg-[#c8a9f1]' />}
             </button>
           </div>
           <div className='py-6'>
@@ -204,23 +206,23 @@ const Profile = () => {
                     {profileReels.map(reel => (
                       <div
                         key={reel._id}
-                        className='group relative overflow-hidden rounded-3xl border border-slate-800/60 bg-slate-950/40 shadow-lg shadow-violet-500/10 transition hover:border-violet-400/40 hover:shadow-violet-500/30'
+                        className='group relative overflow-hidden rounded-3xl border border-[rgba(200,169,241,0.35)] bg-white/80 shadow-[0_24px_60px_-48px_rgba(200,169,241,0.45)] transition hover:border-[#c8a9f1]/60 hover:shadow-[0_28px_72px_-50px_rgba(200,169,241,0.6)]'
                       >
                         <video src={reel.videoUrl} muted loop playsInline className='aspect-[9/16] w-full object-cover' />
-                        <div className='absolute inset-0 flex flex-col justify-between bg-gradient-to-t from-slate-950/80 via-transparent to-transparent p-4 opacity-0 transition group-hover:opacity-100'>
+                        <div className='absolute inset-0 flex flex-col justify-between bg-gradient-to-t from-black/55 via-transparent to-transparent p-4 opacity-0 transition group-hover:opacity-100'>
                           <div className='flex items-center gap-3'>
-                            <Avatar className='h-9 w-9 border border-slate-900/80'>
+                            <Avatar className='h-9 w-9 border border-[rgba(255,255,255,0.6)]'>
                               <AvatarImage src={reel.author?.profilePicture} alt={reel.author?.username} />
                               <AvatarFallback>{reel.author?.username?.slice(0, 2)?.toUpperCase() || 'CN'}</AvatarFallback>
                             </Avatar>
-                            <div className='flex flex-col text-left'>
-                              <span className='text-sm font-semibold text-slate-50'>{reel.caption || 'Shared a new reel'}</span>
-                              <span className='text-xs text-slate-300'>{reel.views?.length || 0} views</span>
+                            <div className='flex flex-col text-left text-white'>
+                              <span className='text-sm font-semibold'>{reel.caption || 'Shared a new reel'}</span>
+                              <span className='text-xs text-white/80'>{reel.views?.length || 0} views</span>
                             </div>
                           </div>
-                          <div className='flex items-center gap-2 text-xs text-slate-100'>
-                            <span className='inline-flex items-center gap-1 rounded-full bg-slate-900/60 px-3 py-1'>
-                              <Heart className='h-3 w-3 text-rose-300' />
+                          <div className='flex items-center gap-2 text-xs text-white'>
+                            <span className='inline-flex items-center gap-1 rounded-full bg-black/40 px-3 py-1'>
+                              <Heart className='h-3 w-3 text-[#f4b9b9]' />
                               {reel.likes?.length || 0}
                             </span>
                           </div>
@@ -229,12 +231,12 @@ const Profile = () => {
                     ))}
                   </div>
                 ) : (
-                  <div className='rounded-3xl border border-slate-800/60 bg-slate-950/40 p-10 text-center text-sm text-slate-400'>
+                  <div className='rounded-3xl border border-[rgba(0,0,0,0.05)] bg-white/70 p-10 text-center text-sm text-[#6f6f6f]'>
                     {getEmptyMessage()}
                   </div>
                 )
               ) : (
-                <div className='flex flex-col items-center gap-2 py-10 text-center text-sm text-gray-500'>
+                <div className='flex flex-col items-center gap-2 py-10 text-center text-sm text-[#8c8c8c]'>
                   <p>This account is private.</p>
                   <p>Send a follow request to see their posts.</p>
                 </div>
@@ -245,17 +247,17 @@ const Profile = () => {
                   {activeCollection.map(post => (
                     <div
                       key={post?._id}
-                      className='group relative overflow-hidden rounded-3xl border border-slate-800/60 bg-slate-950/40 shadow-inner shadow-slate-950/60'
+                      className='group relative overflow-hidden rounded-3xl border border-[rgba(0,0,0,0.05)] bg-white/80 shadow-[0_24px_60px_-50px_rgba(51,51,51,0.35)]'
                     >
                       <img src={post.image} alt='postimage' className='aspect-square w-full object-cover transition duration-300 group-hover:scale-105' />
-                      <div className='absolute inset-0 flex items-center justify-center bg-slate-950/60 opacity-0 transition-opacity duration-300 group-hover:opacity-100'>
-                        <div className='flex items-center gap-6 text-sm font-semibold text-slate-100'>
+                      <div className='absolute inset-0 flex items-center justify-center bg-black/40 opacity-0 transition-opacity duration-300 group-hover:opacity-100'>
+                        <div className='flex items-center gap-6 text-sm font-semibold text-white'>
                           <span className='flex items-center gap-2'>
-                            <Heart className='h-4 w-4 text-rose-300' />
+                            <Heart className='h-4 w-4 text-[#f4b9b9]' />
                             {post?.likes?.length || 0}
                           </span>
                           <span className='flex items-center gap-2'>
-                            <MessageCircle className='h-4 w-4 text-sky-300' />
+                            <MessageCircle className='h-4 w-4 text-[#c8a9f1]' />
                             {post?.comments?.length || 0}
                           </span>
                         </div>
@@ -264,12 +266,12 @@ const Profile = () => {
                   ))}
                 </div>
               ) : (
-                <div className='rounded-3xl border border-slate-800/60 bg-slate-950/40 p-10 text-center text-sm text-slate-400'>
+                <div className='rounded-3xl border border-[rgba(0,0,0,0.05)] bg-white/70 p-10 text-center text-sm text-[#6f6f6f]'>
                   {getEmptyMessage()}
                 </div>
               )
             ) : (
-              <div className='flex flex-col items-center gap-2 py-10 text-center text-sm text-gray-500'>
+              <div className='flex flex-col items-center gap-2 py-10 text-center text-sm text-[#8c8c8c]'>
                 <p>This account is private.</p>
                 <p>Send a follow request to see their posts.</p>
               </div>

--- a/frontend/src/components/Profile.jsx
+++ b/frontend/src/components/Profile.jsx
@@ -4,12 +4,15 @@ import useGetUserProfile from '@/hooks/useGetUserProfile'
 import useReels from '@/hooks/useReels'
 import useGetAllPost from '@/hooks/useGetAllPost'
 import { Link, useParams } from 'react-router-dom'
-import { useSelector } from 'react-redux'
+import { useDispatch, useSelector } from 'react-redux'
 import { Button } from './ui/button'
 import { Badge } from './ui/badge'
 import { AtSign, Heart, MessageCircle } from 'lucide-react'
 import axios from 'axios'
 import { toast } from 'sonner'
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from './ui/dialog'
+import { computeUpdatedAuthUserAfterFollowAction, normaliseIdArray } from '@/lib/relationships'
+import { setAuthUser } from '@/redux/authSlice'
 
 const Profile = () => {
   useReels()
@@ -19,11 +22,18 @@ const Profile = () => {
   const userId = params.id
   const { refetch } = useGetUserProfile(userId)
   const [activeTab, setActiveTab] = useState('posts')
+  const [isConnectionsOpen, setIsConnectionsOpen] = useState(false)
+  const [connectionType, setConnectionType] = useState('followers')
+  const [connections, setConnections] = useState([])
+  const [isLoadingConnections, setIsLoadingConnections] = useState(false)
+  const [connectionError, setConnectionError] = useState(null)
+  const [connectionBusyIds, setConnectionBusyIds] = useState(() => new Set())
 
   useEffect(() => {
     setActiveTab('posts')
   }, [userId])
 
+  const dispatch = useDispatch()
   const { userProfile, user, userProfileMeta } = useSelector(store => store.auth)
   const { reels } = useSelector(store => store.reel)
   const { posts: feedPosts } = useSelector(store => store.post)
@@ -34,6 +44,7 @@ const Profile = () => {
   const canViewProfile = userProfileMeta?.canViewFullProfile || isLoggedInUserProfile
 
   const profileId = userProfile?._id
+  const API_BASE_URL = 'https://let-s-talk-lq7h.onrender.com/api/v1/user'
 
   const handleTabChange = (tab) => {
     setActiveTab(tab)
@@ -82,9 +93,15 @@ const Profile = () => {
 
   const handleFollowAction = async () => {
     try {
-      const res = await axios.post(`https://let-s-talk-lq7h.onrender.com/api/v1/user/followorunfollow/${userId}`, {}, { withCredentials: true })
+      const res = await axios.post(`${API_BASE_URL}/followorunfollow/${userId}`, {}, { withCredentials: true })
       if (res.data.success) {
         toast.success(res.data.message)
+        if (res.data.status) {
+          const updatedAuthUser = computeUpdatedAuthUserAfterFollowAction(user, res.data.status, userId)
+          if (updatedAuthUser) {
+            dispatch(setAuthUser(updatedAuthUser))
+          }
+        }
         await refetch()
       }
     } catch (error) {
@@ -99,6 +116,120 @@ const Profile = () => {
     if (hasPendingRequest) return 'Requested'
     return 'Follow'
   }, [isFollowing, hasPendingRequest, isLoggedInUserProfile])
+
+  const canViewConnections = useMemo(() => {
+    if (isLoggedInUserProfile) return true
+    if (userProfile?.accountType === 'public') return true
+    return Boolean(isFollowing)
+  }, [isFollowing, isLoggedInUserProfile, userProfile?.accountType])
+
+  useEffect(() => {
+    if (!isConnectionsOpen || !connectionType || !userId) return
+
+    let isActive = true
+
+    const fetchConnections = async () => {
+      setIsLoadingConnections(true)
+      setConnectionError(null)
+      try {
+        const res = await axios.get(`${API_BASE_URL}/${userId}/${connectionType}`, { withCredentials: true })
+        if (!isActive) return
+        if (res?.data?.success) {
+          setConnections(res?.data?.users ?? [])
+        } else {
+          setConnections([])
+          setConnectionError(res?.data?.message || 'Unable to load connections right now.')
+        }
+      } catch (error) {
+        if (!isActive) return
+        console.log(error)
+        setConnections([])
+        setConnectionError(error?.response?.data?.message || 'Unable to load connections right now.')
+      } finally {
+        if (isActive) {
+          setIsLoadingConnections(false)
+        }
+      }
+    }
+
+    fetchConnections()
+
+    return () => {
+      isActive = false
+    }
+  }, [API_BASE_URL, connectionType, isConnectionsOpen, userId])
+
+  const handleConnectionsDialogChange = (open) => {
+    setIsConnectionsOpen(open)
+    if (!open) {
+      setConnections([])
+      setConnectionError(null)
+      setConnectionBusyIds(new Set())
+    }
+  }
+
+  const openConnections = (type) => {
+    if (!canViewConnections) {
+      toast.info('Follow this account to see more details about their community.')
+      return
+    }
+    setConnectionType(type)
+    setIsConnectionsOpen(true)
+  }
+
+  const handleConnectionFollowToggle = async (connection) => {
+    const targetId = connection?._id
+    if (!targetId || !user?._id) return
+
+    const idString = targetId.toString()
+    setConnectionBusyIds(prev => {
+      const next = new Set(prev)
+      next.add(idString)
+      return next
+    })
+
+    try {
+      const res = await axios.post(`${API_BASE_URL}/followorunfollow/${idString}`, {}, { withCredentials: true })
+      if (res?.data?.success && res?.data?.status) {
+        const updatedAuthUser = computeUpdatedAuthUserAfterFollowAction(user, res.data.status, idString)
+        if (updatedAuthUser) {
+          dispatch(setAuthUser(updatedAuthUser))
+        }
+
+        setConnections(prev => prev.map(item => {
+          const itemId = item?._id?.toString?.() ?? item?._id
+          if (itemId?.toString() !== idString) return item
+
+          switch (res.data.status) {
+            case 'followed':
+              return { ...item, isFollowing: true, hasPendingRequest: false }
+            case 'unfollowed':
+              return { ...item, isFollowing: false, hasPendingRequest: false }
+            case 'requested':
+              return { ...item, isFollowing: false, hasPendingRequest: true }
+            case 'request_cancelled':
+              return { ...item, isFollowing: false, hasPendingRequest: false }
+            default:
+              return item
+          }
+        }))
+
+        toast.success(res.data.message)
+      }
+    } catch (error) {
+      console.log(error)
+      toast.error(error?.response?.data?.message || 'Unable to update follow status')
+    } finally {
+      setConnectionBusyIds(prev => {
+        const next = new Set(prev)
+        next.delete(idString)
+        return next
+      })
+    }
+  }
+
+  const viewerFollowingIds = useMemo(() => new Set(normaliseIdArray(user?.following)), [user?.following])
+  const viewerPendingIds = useMemo(() => new Set(normaliseIdArray(user?.sentFollowRequests)), [user?.sentFollowRequests])
 
   return (
     <div className='mx-auto flex max-w-6xl justify-center px-4 py-6 text-[#4a4a4a]'>
@@ -142,8 +273,20 @@ const Profile = () => {
               </div>
               <div className='flex flex-wrap items-center gap-4 text-sm text-[#6f6f6f]'>
                 <p><span className='font-semibold text-[#333333]'>{userProfile?.posts.length} </span>posts</p>
-                <p><span className='font-semibold text-[#333333]'>{userProfile?.followers.length} </span>followers</p>
-                <p><span className='font-semibold text-[#333333]'>{userProfile?.following.length} </span>following</p>
+                <button
+                  type='button'
+                  onClick={() => openConnections('followers')}
+                  className='transition hover:text-[#333333]'
+                >
+                  <span className='font-semibold text-[#333333]'>{userProfile?.followers.length} </span>followers
+                </button>
+                <button
+                  type='button'
+                  onClick={() => openConnections('following')}
+                  className='transition hover:text-[#333333]'
+                >
+                  <span className='font-semibold text-[#333333]'>{userProfile?.following.length} </span>following
+                </button>
               </div>
               <div className='flex flex-col gap-1'>
                 <span className='font-semibold text-[#333333]'>{userProfile?.bio || 'bio here...'}</span>
@@ -279,6 +422,90 @@ const Profile = () => {
           </div>
         </div>
       </div>
+      <Dialog open={isConnectionsOpen} onOpenChange={handleConnectionsDialogChange}>
+        <DialogContent className='max-w-xl'>
+          <DialogHeader>
+            <DialogTitle className='text-center text-lg font-semibold text-[#333333] sm:text-left'>
+              {connectionType === 'followers' ? 'Followers' : 'Following'}
+            </DialogTitle>
+            <DialogDescription className='text-center text-sm text-[#666666] sm:text-left'>
+              {connectionType === 'followers'
+                ? `People who follow ${userProfile?.username || 'this account'}`
+                : `Accounts ${userProfile?.username || 'this account'} follows`}
+            </DialogDescription>
+          </DialogHeader>
+          <div className='flex items-center justify-center gap-2 rounded-full bg-[#f6f6f6] p-1 text-xs font-semibold text-[#4a4a4a]'>
+            <button
+              type='button'
+              onClick={() => setConnectionType('followers')}
+              className={`w-full rounded-full px-4 py-2 transition ${connectionType === 'followers' ? 'bg-white text-[#333333] shadow-[0_8px_20px_-14px_rgba(0,0,0,0.45)]' : 'text-[#777777]'}`}
+            >
+              Followers
+            </button>
+            <button
+              type='button'
+              onClick={() => setConnectionType('following')}
+              className={`w-full rounded-full px-4 py-2 transition ${connectionType === 'following' ? 'bg-white text-[#333333] shadow-[0_8px_20px_-14px_rgba(0,0,0,0.45)]' : 'text-[#777777]'}`}
+            >
+              Following
+            </button>
+          </div>
+          <div className='mt-4 max-h-[420px] space-y-3 overflow-y-auto pr-1'>
+            {isLoadingConnections && (
+              <div className='flex items-center justify-center rounded-2xl border border-dashed border-[#d9d9d9] bg-white/60 py-10 text-sm text-[#666666]'>
+                Loading {connectionType}…
+              </div>
+            )}
+            {!isLoadingConnections && connectionError && (
+              <div className='rounded-2xl border border-dashed border-[#d9d9d9] bg-white/65 p-6 text-center text-sm text-[#6f6f6f]'>
+                {connectionError}
+              </div>
+            )}
+            {!isLoadingConnections && !connectionError && !connections.length && (
+              <div className='rounded-2xl border border-dashed border-[#d9d9d9] bg-white/65 p-6 text-center text-sm text-[#6f6f6f]'>
+                {connectionType === 'followers' ? 'No followers to show yet.' : 'Not following anyone yet.'}
+              </div>
+            )}
+            {!isLoadingConnections && !connectionError && connections.map(connection => {
+              const connectionId = connection?._id?.toString?.() ?? connection?._id
+              const isViewer = connectionId === (user?._id?.toString?.() ?? user?._id)
+              const isBusy = connectionBusyIds.has(connectionId)
+              const isFollowingConnection = connection?.isFollowing ?? viewerFollowingIds.has(connectionId)
+              const hasPendingRequest = connection?.hasPendingRequest ?? viewerPendingIds.has(connectionId)
+              const buttonLabel = isFollowingConnection ? 'Following' : hasPendingRequest ? 'Requested' : 'Follow'
+              const buttonVariant = isFollowingConnection ? 'secondary' : hasPendingRequest ? 'secondary' : 'default'
+
+              return (
+                <div key={connectionId} className='flex items-center justify-between gap-3 rounded-2xl border border-[rgba(0,0,0,0.04)] bg-white/80 px-4 py-3 shadow-[0_16px_32px_-42px_rgba(51,51,51,0.45)]'>
+                  <Link to={`/profile/${connectionId}`} className='flex flex-1 items-center gap-3'>
+                    <Avatar className='h-11 w-11 border border-[rgba(0,0,0,0.05)] bg-white'>
+                      <AvatarImage src={connection?.profilePicture} alt={`${connection?.username || 'user'}-avatar`} />
+                      <AvatarFallback>LT</AvatarFallback>
+                    </Avatar>
+                    <div className='min-w-0'>
+                      <p className='truncate text-sm font-semibold text-[#333333]'>{connection?.username}</p>
+                      {connection?.bio && <p className='truncate text-xs text-[#6f6f6f]'>{connection.bio}</p>}
+                    </div>
+                  </Link>
+                  {isViewer ? (
+                    <span className='rounded-full bg-[#f6f6f6] px-3 py-1 text-xs font-semibold text-[#777777]'>You</span>
+                  ) : (
+                    <Button
+                      size='sm'
+                      className='rounded-full px-4'
+                      disabled={isBusy}
+                      variant={buttonVariant}
+                      onClick={() => handleConnectionFollowToggle(connection)}
+                    >
+                      {isBusy ? 'Please wait…' : buttonLabel}
+                    </Button>
+                  )}
+                </div>
+              )
+            })}
+          </div>
+        </DialogContent>
+      </Dialog>
     </div>
   )
 }

--- a/frontend/src/components/Profile.jsx
+++ b/frontend/src/components/Profile.jsx
@@ -13,6 +13,7 @@ import { toast } from 'sonner'
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from './ui/dialog'
 import { computeUpdatedAuthUserAfterFollowAction, normaliseIdArray } from '@/lib/relationships'
 import { setAuthUser } from '@/redux/authSlice'
+import ReelPlayerDialog from './ReelPlayerDialog'
 
 const Profile = () => {
   useReels()
@@ -28,6 +29,8 @@ const Profile = () => {
   const [isLoadingConnections, setIsLoadingConnections] = useState(false)
   const [connectionError, setConnectionError] = useState(null)
   const [connectionBusyIds, setConnectionBusyIds] = useState(() => new Set())
+  const [activeReel, setActiveReel] = useState(null)
+  const [isReelDialogOpen, setIsReelDialogOpen] = useState(false)
 
   useEffect(() => {
     setActiveTab('posts')
@@ -231,6 +234,19 @@ const Profile = () => {
   const viewerFollowingIds = useMemo(() => new Set(normaliseIdArray(user?.following)), [user?.following])
   const viewerPendingIds = useMemo(() => new Set(normaliseIdArray(user?.sentFollowRequests)), [user?.sentFollowRequests])
 
+  const handleOpenReel = (reel) => {
+    if (!reel) return
+    setActiveReel(reel)
+    setIsReelDialogOpen(true)
+  }
+
+  const handleReelDialogChange = (open) => {
+    setIsReelDialogOpen(open)
+    if (!open) {
+      setActiveReel(null)
+    }
+  }
+
   return (
     <div className='mx-auto flex max-w-6xl justify-center px-4 py-6 text-[#4a4a4a]'>
       <div className='flex w-full flex-col gap-12 rounded-[2.5rem] border border-[rgba(0,0,0,0.05)] bg-white/85 p-8 shadow-[0_32px_80px_-58px_rgba(51,51,51,0.5)]'>
@@ -347,12 +363,14 @@ const Profile = () => {
                 profileReels.length ? (
                   <div className='grid gap-4 sm:grid-cols-2 lg:grid-cols-3'>
                     {profileReels.map(reel => (
-                      <div
+                      <button
+                        type='button'
                         key={reel._id}
+                        onClick={() => handleOpenReel(reel)}
                         className='group relative overflow-hidden rounded-3xl border border-[rgba(200,169,241,0.35)] bg-white/80 shadow-[0_24px_60px_-48px_rgba(200,169,241,0.45)] transition hover:border-[#c8a9f1]/60 hover:shadow-[0_28px_72px_-50px_rgba(200,169,241,0.6)]'
                       >
-                        <video src={reel.videoUrl} muted loop playsInline className='aspect-[9/16] w-full object-cover' />
-                        <div className='absolute inset-0 flex flex-col justify-between bg-gradient-to-t from-black/55 via-transparent to-transparent p-4 opacity-0 transition group-hover:opacity-100'>
+                        <video src={reel.videoUrl} muted loop playsInline className='pointer-events-none aspect-[9/16] w-full object-cover' />
+                        <div className='pointer-events-none absolute inset-0 flex flex-col justify-between bg-gradient-to-t from-black/55 via-transparent to-transparent p-4 opacity-0 transition group-hover:opacity-100'>
                           <div className='flex items-center gap-3'>
                             <Avatar className='h-9 w-9 border border-[rgba(255,255,255,0.6)]'>
                               <AvatarImage src={reel.author?.profilePicture} alt={reel.author?.username} />
@@ -370,7 +388,7 @@ const Profile = () => {
                             </span>
                           </div>
                         </div>
-                      </div>
+                      </button>
                     ))}
                   </div>
                 ) : (
@@ -387,26 +405,39 @@ const Profile = () => {
             ) : canViewProfile || (activeTab === 'saved' && isLoggedInUserProfile) ? (
               activeCollection.length ? (
                 <div className='grid grid-cols-2 gap-3 sm:grid-cols-3 sm:gap-4'>
-                  {activeCollection.map(post => (
-                    <div
-                      key={post?._id}
-                      className='group relative overflow-hidden rounded-3xl border border-[rgba(0,0,0,0.05)] bg-white/80 shadow-[0_24px_60px_-50px_rgba(51,51,51,0.35)]'
-                    >
-                      <img src={post.image} alt='postimage' className='aspect-square w-full object-cover transition duration-300 group-hover:scale-105' />
-                      <div className='absolute inset-0 flex items-center justify-center bg-black/40 opacity-0 transition-opacity duration-300 group-hover:opacity-100'>
-                        <div className='flex items-center gap-6 text-sm font-semibold text-white'>
-                          <span className='flex items-center gap-2'>
-                            <Heart className='h-4 w-4 text-[#f4b9b9]' />
-                            {post?.likes?.length || 0}
-                          </span>
-                          <span className='flex items-center gap-2'>
-                            <MessageCircle className='h-4 w-4 text-[#c8a9f1]' />
-                            {post?.comments?.length || 0}
-                          </span>
+                  {activeCollection.map((post, index) => {
+                    const postId = post?._id?.toString?.() ?? post?._id
+                    const key = postId || `profile-post-${index}`
+                    const CardContent = (
+                      <>
+                        <img src={post.image} alt='postimage' className='aspect-square w-full object-cover transition duration-300 group-hover:scale-105' />
+                        <div className='absolute inset-0 flex items-center justify-center bg-black/40 opacity-0 transition-opacity duration-300 group-hover:opacity-100'>
+                          <div className='flex items-center gap-6 text-sm font-semibold text-white'>
+                            <span className='flex items-center gap-2'>
+                              <Heart className='h-4 w-4 text-[#f4b9b9]' />
+                              {post?.likes?.length || 0}
+                            </span>
+                            <span className='flex items-center gap-2'>
+                              <MessageCircle className='h-4 w-4 text-[#c8a9f1]' />
+                              {post?.comments?.length || 0}
+                            </span>
+                          </div>
                         </div>
+                      </>
+                    )
+
+                    const baseClass = 'group relative overflow-hidden rounded-3xl border border-[rgba(0,0,0,0.05)] bg-white/80 shadow-[0_24px_60px_-50px_rgba(51,51,51,0.35)]'
+
+                    return postId ? (
+                      <Link key={key} to={`/p/${postId}`} className={`block ${baseClass}`}>
+                        {CardContent}
+                      </Link>
+                    ) : (
+                      <div key={key} className={baseClass}>
+                        {CardContent}
                       </div>
-                    </div>
-                  ))}
+                    )
+                  })}
                 </div>
               ) : (
                 <div className='rounded-3xl border border-[rgba(0,0,0,0.05)] bg-white/70 p-10 text-center text-sm text-[#6f6f6f]'>
@@ -472,7 +503,14 @@ const Profile = () => {
               const isBusy = connectionBusyIds.has(connectionId)
               const isFollowingConnection = connection?.isFollowing ?? viewerFollowingIds.has(connectionId)
               const hasPendingRequest = connection?.hasPendingRequest ?? viewerPendingIds.has(connectionId)
-              const buttonLabel = isFollowingConnection ? 'Following' : hasPendingRequest ? 'Requested' : 'Follow'
+              const followsViewer = connectionType === 'followers' && isLoggedInUserProfile
+              const buttonLabel = isFollowingConnection
+                ? 'Following'
+                : hasPendingRequest
+                  ? 'Requested'
+                  : followsViewer
+                    ? 'Follow back'
+                    : 'Follow'
               const buttonVariant = isFollowingConnection ? 'secondary' : hasPendingRequest ? 'secondary' : 'default'
 
               return (
@@ -484,6 +522,9 @@ const Profile = () => {
                     </Avatar>
                     <div className='min-w-0'>
                       <p className='truncate text-sm font-semibold text-[#333333]'>{connection?.username}</p>
+                      {connectionType === 'followers' && isLoggedInUserProfile && !isViewer && (
+                        <p className='text-xs text-[#8c8c8c]'>Follows you</p>
+                      )}
                       {connection?.bio && <p className='truncate text-xs text-[#6f6f6f]'>{connection.bio}</p>}
                     </div>
                   </Link>
@@ -506,6 +547,7 @@ const Profile = () => {
           </div>
         </DialogContent>
       </Dialog>
+      <ReelPlayerDialog reel={activeReel} open={isReelDialogOpen} onOpenChange={handleReelDialogChange} />
     </div>
   )
 }

--- a/frontend/src/components/ProtectedRoutes.jsx
+++ b/frontend/src/components/ProtectedRoutes.jsx
@@ -1,16 +1,18 @@
-import React, { useEffect } from 'react'
+import { useEffect } from 'react'
 import { useSelector } from 'react-redux'
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom'
 
-const ProtectedRoutes = ({children}) => {
-    const {user} = useSelector(store=>store.auth);
-    const navigate = useNavigate();
-    useEffect(()=>{
-        if(!user){
-            navigate("/login");
-        }
-    },[])
+const ProtectedRoutes = ({ children }) => {
+  const { user } = useSelector(store => store.auth)
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    if (!user) {
+      navigate('/login')
+    }
+  }, [navigate, user])
+
   return <>{children}</>
 }
 
-export default ProtectedRoutes;
+export default ProtectedRoutes

--- a/frontend/src/components/ReelCard.jsx
+++ b/frontend/src/components/ReelCard.jsx
@@ -1,88 +1,94 @@
-import React, { useState } from 'react';
-import { Avatar, AvatarFallback, AvatarImage } from './ui/avatar';
-import { Button } from './ui/button';
-import { Heart, Play } from 'lucide-react';
-import { useDispatch, useSelector } from 'react-redux';
-import axios from 'axios';
-import { toggleReelLike } from '@/redux/reelSlice';
+import { useState } from 'react'
+import { Avatar, AvatarFallback, AvatarImage } from './ui/avatar'
+import { Button } from './ui/button'
+import { Heart, Play } from 'lucide-react'
+import { useDispatch, useSelector } from 'react-redux'
+import axios from 'axios'
+import { toggleReelLike } from '@/redux/reelSlice'
 
 const ReelCard = ({ reel }) => {
-    const { user } = useSelector(store => store.auth);
-    const dispatch = useDispatch();
-    const [viewed, setViewed] = useState(reel.views?.includes(user?._id));
-    const [likeLoading, setLikeLoading] = useState(false);
-    const isLiked = reel.likes?.includes(user?._id);
+  const { user } = useSelector(store => store.auth)
+  const dispatch = useDispatch()
+  const [viewed, setViewed] = useState(reel.views?.includes(user?._id))
+  const [likeLoading, setLikeLoading] = useState(false)
+  const isLiked = reel.likes?.includes(user?._id)
 
-    const toggleLike = async () => {
-        if(!user?._id) return;
-        try {
-            setLikeLoading(true);
-            if(isLiked){
-                await axios.post(`https://let-s-talk-lq7h.onrender.com/api/v1/reel/${reel._id}/unlike`, {}, { withCredentials: true });
-                dispatch(toggleReelLike({ reelId: reel._id, userId: user._id, liked: false }));
-            }else{
-                await axios.post(`https://let-s-talk-lq7h.onrender.com/api/v1/reel/${reel._id}/like`, {}, { withCredentials: true });
-                dispatch(toggleReelLike({ reelId: reel._id, userId: user._id, liked: true }));
-            }
-        } catch (error) {
-            console.log(error);
-        } finally {
-            setLikeLoading(false);
-        }
-    };
+  const toggleLike = async () => {
+    if (!user?._id) return
+    try {
+      setLikeLoading(true)
+      if (isLiked) {
+        await axios.post(`https://let-s-talk-lq7h.onrender.com/api/v1/reel/${reel._id}/unlike`, {}, { withCredentials: true })
+        dispatch(toggleReelLike({ reelId: reel._id, userId: user._id, liked: false }))
+      } else {
+        await axios.post(`https://let-s-talk-lq7h.onrender.com/api/v1/reel/${reel._id}/like`, {}, { withCredentials: true })
+        dispatch(toggleReelLike({ reelId: reel._id, userId: user._id, liked: true }))
+      }
+    } catch (error) {
+      console.log(error)
+    } finally {
+      setLikeLoading(false)
+    }
+  }
 
-    const markView = async () => {
-        if(viewed || !user?._id) return;
-        try {
-            setViewed(true);
-            await axios.post(`https://let-s-talk-lq7h.onrender.com/api/v1/reel/${reel._id}/view`, {}, { withCredentials: true });
-        } catch (error) {
-            console.log(error);
-        }
-    };
+  const markView = async () => {
+    if (viewed || !user?._id) return
+    try {
+      setViewed(true)
+      await axios.post(`https://let-s-talk-lq7h.onrender.com/api/v1/reel/${reel._id}/view`, {}, { withCredentials: true })
+    } catch (error) {
+      console.log(error)
+    }
+  }
 
-    return (
-        <div className='bg-white border border-gray-200 rounded-2xl overflow-hidden shadow-sm'>
-            <div className='flex items-center gap-3 px-4 py-3'>
-                <Avatar>
-                    <AvatarImage src={reel.author?.profilePicture} />
-                    <AvatarFallback>AU</AvatarFallback>
-                </Avatar>
-                <div className='flex flex-col'>
-                    <span className='text-sm font-semibold'>{reel.author?.username}</span>
-                    <span className='text-xs text-gray-500'>{new Date(reel.createdAt).toLocaleString()}</span>
-                </div>
-            </div>
-            <div className='relative bg-black'>
-                <video
-                    src={reel.videoUrl}
-                    controls
-                    playsInline
-                    className='w-full max-h-[480px] object-contain bg-black'
-                    onPlay={markView}
-                />
-                <div className='absolute bottom-3 left-3 flex items-center gap-2 text-white text-xs bg-black/40 px-2 py-1 rounded-full'>
-                    <Play size={14} />
-                    <span>{reel.views?.length || 0} views</span>
-                </div>
-            </div>
-            <div className='p-4 flex flex-col gap-3'>
-                <div className='flex items-center gap-3'>
-                    <Button variant={isLiked ? 'default' : 'outline'} size='sm' onClick={toggleLike} disabled={likeLoading}>
-                        <Heart className={`h-4 w-4 mr-2 ${isLiked ? 'fill-current' : ''}`} />
-                        {isLiked ? 'Liked' : 'Like'}
-                    </Button>
-                    <span className='text-xs text-gray-500'>{reel.likes?.length || 0} likes</span>
-                </div>
-                {reel.caption && (
-                    <p className='text-sm text-gray-700'>
-                        <span className='font-semibold mr-2'>{reel.author?.username}</span>
-                        {reel.caption}
-                    </p>
-                )}
-            </div>
+  return (
+    <div className='overflow-hidden rounded-[1.75rem] border border-slate-800/60 bg-slate-950/50 shadow-lg shadow-sky-500/10'>
+      <div className='flex items-center gap-3 px-5 py-4'>
+        <Avatar className='h-10 w-10 border border-slate-900'>
+          <AvatarImage src={reel.author?.profilePicture} />
+          <AvatarFallback>AU</AvatarFallback>
+        </Avatar>
+        <div className='flex flex-col'>
+          <span className='text-sm font-semibold text-slate-100'>{reel.author?.username}</span>
+          <span className='text-xs text-slate-500'>{new Date(reel.createdAt).toLocaleString()}</span>
         </div>
-    );
-};
+      </div>
+      <div className='relative bg-black'>
+        <video
+          src={reel.videoUrl}
+          controls
+          playsInline
+          className='w-full max-h-[480px] object-contain bg-black'
+          onPlay={markView}
+        />
+        <div className='absolute bottom-4 left-4 flex items-center gap-2 rounded-full bg-black/50 px-3 py-1 text-xs text-white'>
+          <Play size={14} />
+          <span>{reel.views?.length || 0} views</span>
+        </div>
+      </div>
+      <div className='flex flex-col gap-3 p-5 text-sm text-slate-200'>
+        <div className='flex items-center gap-3'>
+          <Button
+            variant={isLiked ? 'default' : 'outline'}
+            size='sm'
+            onClick={toggleLike}
+            disabled={likeLoading}
+            className={isLiked ? 'bg-rose-400/90 text-slate-950 hover:bg-rose-400' : 'border-slate-700/80 text-slate-300 hover:bg-slate-900/80'}
+          >
+            <Heart className={`mr-2 h-4 w-4 ${isLiked ? 'fill-current text-slate-950' : ''}`} />
+            {isLiked ? 'Liked' : 'Appreciate'}
+          </Button>
+          <span className='text-xs text-slate-500'>{reel.likes?.length || 0} appreciations</span>
+        </div>
+        {reel.caption && (
+          <p className='leading-6 text-slate-300'>
+            <span className='mr-2 font-semibold text-slate-100'>{reel.author?.username}</span>
+            {reel.caption}
+          </p>
+        )}
+      </div>
+    </div>
+  )
+}
 
-export default ReelCard;
+export default ReelCard

--- a/frontend/src/components/ReelCard.jsx
+++ b/frontend/src/components/ReelCard.jsx
@@ -42,15 +42,15 @@ const ReelCard = ({ reel }) => {
   }
 
   return (
-    <div className='overflow-hidden rounded-[1.75rem] border border-slate-800/60 bg-slate-950/50 shadow-lg shadow-sky-500/10'>
+    <div className='overflow-hidden rounded-[1.75rem] border border-[rgba(0,0,0,0.05)] bg-white/85 shadow-[0_28px_70px_-55px_rgba(200,169,241,0.55)]'>
       <div className='flex items-center gap-3 px-5 py-4'>
-        <Avatar className='h-10 w-10 border border-slate-900'>
+        <Avatar className='h-10 w-10 border border-[rgba(0,0,0,0.05)] bg-white'>
           <AvatarImage src={reel.author?.profilePicture} />
           <AvatarFallback>AU</AvatarFallback>
         </Avatar>
         <div className='flex flex-col'>
-          <span className='text-sm font-semibold text-slate-100'>{reel.author?.username}</span>
-          <span className='text-xs text-slate-500'>{new Date(reel.createdAt).toLocaleString()}</span>
+          <span className='text-sm font-semibold text-[#333333]'>{reel.author?.username}</span>
+          <span className='text-xs text-[#8c8c8c]'>{new Date(reel.createdAt).toLocaleString()}</span>
         </div>
       </div>
       <div className='relative bg-black'>
@@ -66,23 +66,23 @@ const ReelCard = ({ reel }) => {
           <span>{reel.views?.length || 0} views</span>
         </div>
       </div>
-      <div className='flex flex-col gap-3 p-5 text-sm text-slate-200'>
+      <div className='flex flex-col gap-3 p-5 text-sm text-[#4a4a4a]'>
         <div className='flex items-center gap-3'>
           <Button
-            variant={isLiked ? 'default' : 'outline'}
+            variant='outline'
             size='sm'
             onClick={toggleLike}
             disabled={likeLoading}
-            className={isLiked ? 'bg-rose-400/90 text-slate-950 hover:bg-rose-400' : 'border-slate-700/80 text-slate-300 hover:bg-slate-900/80'}
+            className={isLiked ? 'border-transparent bg-[#d66c6c] text-white hover:bg-[#c45c5c]' : 'border-[rgba(0,0,0,0.1)] text-[#6f6f6f] hover:bg-white'}
           >
-            <Heart className={`mr-2 h-4 w-4 ${isLiked ? 'fill-current text-slate-950' : ''}`} />
+            <Heart className={`mr-2 h-4 w-4 ${isLiked ? 'fill-current text-white' : 'text-[#d66c6c]'}`} />
             {isLiked ? 'Liked' : 'Appreciate'}
           </Button>
-          <span className='text-xs text-slate-500'>{reel.likes?.length || 0} appreciations</span>
+          <span className='text-xs text-[#8c8c8c]'>{reel.likes?.length || 0} appreciations</span>
         </div>
         {reel.caption && (
-          <p className='leading-6 text-slate-300'>
-            <span className='mr-2 font-semibold text-slate-100'>{reel.author?.username}</span>
+          <p className='leading-6 text-[#4a4a4a]'>
+            <span className='mr-2 font-semibold text-[#333333]'>{reel.author?.username}</span>
             {reel.caption}
           </p>
         )}

--- a/frontend/src/components/ReelPlayerDialog.jsx
+++ b/frontend/src/components/ReelPlayerDialog.jsx
@@ -4,15 +4,15 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from './ui/dialog'
 const ReelPlayerDialog = ({ reel, open, onOpenChange }) => {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className='max-w-3xl overflow-hidden border border-slate-800/60 bg-slate-900/80 p-0 text-slate-100 shadow-xl shadow-violet-500/20'>
-        <DialogHeader className='border-b border-slate-800/60 px-6 py-4'>
-          <DialogTitle className='text-base font-semibold text-slate-100'>Reel preview</DialogTitle>
+      <DialogContent className='max-w-3xl overflow-hidden border border-[rgba(0,0,0,0.05)] bg-white/90 p-0 text-[#4a4a4a] shadow-[0_32px_80px_-58px_rgba(200,169,241,0.55)]'>
+        <DialogHeader className='border-b border-[rgba(0,0,0,0.05)] bg-white/80 px-6 py-4'>
+          <DialogTitle className='text-base font-semibold text-[#333333]'>Reel preview</DialogTitle>
         </DialogHeader>
         <div className='max-h-[80vh] overflow-y-auto p-6'>
           {reel ? (
             <ReelCard reel={reel} />
           ) : (
-            <div className='rounded-2xl border border-slate-800/60 bg-slate-950/60 p-10 text-center text-sm text-slate-400'>
+            <div className='rounded-2xl border border-[rgba(0,0,0,0.05)] bg-white/70 p-10 text-center text-sm text-[#6f6f6f]'>
               Choose a reel to watch in full.
             </div>
           )}

--- a/frontend/src/components/ReelPlayerDialog.jsx
+++ b/frontend/src/components/ReelPlayerDialog.jsx
@@ -1,0 +1,25 @@
+import ReelCard from './ReelCard'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from './ui/dialog'
+
+const ReelPlayerDialog = ({ reel, open, onOpenChange }) => {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className='max-w-3xl overflow-hidden border border-slate-800/60 bg-slate-900/80 p-0 text-slate-100 shadow-xl shadow-violet-500/20'>
+        <DialogHeader className='border-b border-slate-800/60 px-6 py-4'>
+          <DialogTitle className='text-base font-semibold text-slate-100'>Reel preview</DialogTitle>
+        </DialogHeader>
+        <div className='max-h-[80vh] overflow-y-auto p-6'>
+          {reel ? (
+            <ReelCard reel={reel} />
+          ) : (
+            <div className='rounded-2xl border border-slate-800/60 bg-slate-950/60 p-10 text-center text-sm text-slate-400'>
+              Choose a reel to watch in full.
+            </div>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export default ReelPlayerDialog

--- a/frontend/src/components/ReelsShelf.jsx
+++ b/frontend/src/components/ReelsShelf.jsx
@@ -6,18 +6,18 @@ const ReelsShelf = () => {
   const { reels, isLoading } = useSelector(store => store.reel)
 
   return (
-    <div className='rounded-[2rem] border border-slate-800/60 bg-slate-900/60 p-6 shadow-xl shadow-sky-500/10 backdrop-blur-xl'>
+    <div className='rounded-[2rem] border border-[rgba(0,0,0,0.05)] bg-white/80 p-6 text-[#4a4a4a] shadow-[0_24px_60px_-48px_rgba(51,51,51,0.45)] backdrop-blur-xl'>
       <div className='mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between'>
         <div>
-          <h2 className='text-sm font-semibold text-slate-100'>Reels</h2>
-          <p className='text-xs text-slate-400'>Vertical stories from your creative circles.</p>
+          <h2 className='text-sm font-semibold text-[#333333]'>Reels</h2>
+          <p className='text-xs text-[#8c8c8c]'>Vertical stories from your creative circles.</p>
         </div>
         <ReelComposer />
       </div>
       {isLoading ? (
-        <div className='py-10 text-center text-sm text-slate-400'>Loading reels...</div>
+        <div className='py-10 text-center text-sm text-[#8c8c8c]'>Loading reels...</div>
       ) : reels.length === 0 ? (
-        <div className='py-10 text-center text-sm text-slate-400'>No reels yet. Be the first to share!</div>
+        <div className='py-10 text-center text-sm text-[#8c8c8c]'>No reels yet. Be the first to share!</div>
       ) : (
         <div className='flex flex-col gap-6'>
           {reels.map(reel => <ReelCard key={reel._id} reel={reel} />)}

--- a/frontend/src/components/ReelsShelf.jsx
+++ b/frontend/src/components/ReelsShelf.jsx
@@ -1,33 +1,30 @@
-import React from 'react';
-import { useSelector } from 'react-redux';
-import ReelComposer from './ReelComposer';
-import ReelCard from './ReelCard';
+import { useSelector } from 'react-redux'
+import ReelComposer from './ReelComposer'
+import ReelCard from './ReelCard'
 
 const ReelsShelf = () => {
-    const { reels, isLoading } = useSelector(store => store.reel);
+  const { reels, isLoading } = useSelector(store => store.reel)
 
-    return (
-        <div className='w-full bg-white border border-gray-200 rounded-2xl p-4 shadow-sm flex flex-col gap-4'>
-            <div className='flex items-center justify-between'>
-                <div>
-                    <h2 className='font-semibold text-sm'>Reels</h2>
-                    <p className='text-xs text-gray-500'>Enjoy full-screen vertical videos from your network.</p>
-                </div>
-                <ReelComposer />
-            </div>
-            {
-                isLoading ? (
-                    <div className='text-center text-sm text-gray-500 py-10'>Loading reels...</div>
-                ) : reels.length === 0 ? (
-                    <div className='text-center text-sm text-gray-500 py-10'>No reels yet. Be the first to share!</div>
-                ) : (
-                    <div className='flex flex-col gap-6'>
-                        {reels.map(reel => <ReelCard key={reel._id} reel={reel} />)}
-                    </div>
-                )
-            }
+  return (
+    <div className='rounded-[2rem] border border-slate-800/60 bg-slate-900/60 p-6 shadow-xl shadow-sky-500/10 backdrop-blur-xl'>
+      <div className='mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between'>
+        <div>
+          <h2 className='text-sm font-semibold text-slate-100'>Reels</h2>
+          <p className='text-xs text-slate-400'>Vertical stories from your creative circles.</p>
         </div>
-    );
-};
+        <ReelComposer />
+      </div>
+      {isLoading ? (
+        <div className='py-10 text-center text-sm text-slate-400'>Loading reels...</div>
+      ) : reels.length === 0 ? (
+        <div className='py-10 text-center text-sm text-slate-400'>No reels yet. Be the first to share!</div>
+      ) : (
+        <div className='flex flex-col gap-6'>
+          {reels.map(reel => <ReelCard key={reel._id} reel={reel} />)}
+        </div>
+      )}
+    </div>
+  )
+}
 
-export default ReelsShelf;
+export default ReelsShelf

--- a/frontend/src/components/RightSidebar.jsx
+++ b/frontend/src/components/RightSidebar.jsx
@@ -1,27 +1,40 @@
-import React from 'react'
 import { Avatar, AvatarFallback, AvatarImage } from './ui/avatar'
 import { useSelector } from 'react-redux'
-import { Link } from 'react-router-dom';
-import SuggestedUsers from './SuggestedUsers';
-import FollowRequests from './FollowRequests';
+import { Link } from 'react-router-dom'
+import SuggestedUsers from './SuggestedUsers'
+import FollowRequests from './FollowRequests'
+import { Sparkles } from 'lucide-react'
 
 const RightSidebar = () => {
-  const { user } = useSelector(store => store.auth);
+  const { user } = useSelector(store => store.auth)
   return (
-    <div className='w-fit my-10 pr-32'>
-      <div className='flex items-center gap-2'>
-        <Link to={`/profile/${user?._id}`}>
-          <Avatar>
-            <AvatarImage src={user?.profilePicture} alt="post_image" />
+    <div className='sticky top-24 flex flex-col gap-6 rounded-[2.5rem] border border-slate-800/60 bg-slate-900/60 p-6 text-slate-100 shadow-xl shadow-sky-500/10 backdrop-blur-xl'>
+      <div className='flex items-center gap-3 rounded-2xl border border-slate-800/60 bg-slate-950/40 p-4'>
+        <Link to={`/profile/${user?._id}`} className='rounded-2xl bg-gradient-to-br from-emerald-400/40 via-sky-500/30 to-indigo-500/20 p-[2px]'>
+          <Avatar className='h-12 w-12 border border-slate-900'>
+            <AvatarImage src={user?.profilePicture} alt='post_image' />
             <AvatarFallback>CN</AvatarFallback>
           </Avatar>
         </Link>
-        <div>
-          <h1 className='font-semibold text-sm'><Link to={`/profile/${user?._id}`}>{user?.username}</Link></h1>
-          <span className='text-gray-600 text-sm'>{user?.bio || 'Bio here...'}</span>
+        <div className='flex flex-col'>
+          <h1 className='text-sm font-semibold text-slate-100'>
+            <Link to={`/profile/${user?._id}`}>{user?.username}</Link>
+          </h1>
+          <span className='text-xs text-slate-400'>{user?.bio || 'Share a glimpse of your world today.'}</span>
         </div>
       </div>
-      <SuggestedUsers/>
+      <div className='rounded-2xl border border-slate-800/60 bg-gradient-to-br from-sky-500/10 via-transparent to-emerald-400/10 p-5 text-xs text-slate-200 shadow-inner shadow-sky-500/10'>
+        <div className='flex items-start gap-3'>
+          <span className='rounded-2xl bg-slate-950/60 p-2 text-emerald-300'>
+            <Sparkles className='h-4 w-4' />
+          </span>
+          <div className='space-y-1'>
+            <p className='text-sm font-semibold text-slate-100'>Creator cues</p>
+            <p>Drop a reel or story to stay on top of the community radar.</p>
+          </div>
+        </div>
+      </div>
+      <SuggestedUsers />
       <FollowRequests />
     </div>
   )

--- a/frontend/src/components/RightSidebar.jsx
+++ b/frontend/src/components/RightSidebar.jsx
@@ -8,28 +8,28 @@ import { Sparkles } from 'lucide-react'
 const RightSidebar = () => {
   const { user } = useSelector(store => store.auth)
   return (
-    <div className='sticky top-24 flex flex-col gap-6 rounded-[2.5rem] border border-slate-800/60 bg-slate-900/60 p-6 text-slate-100 shadow-xl shadow-sky-500/10 backdrop-blur-xl'>
-      <div className='flex items-center gap-3 rounded-2xl border border-slate-800/60 bg-slate-950/40 p-4'>
-        <Link to={`/profile/${user?._id}`} className='rounded-2xl bg-gradient-to-br from-emerald-400/40 via-sky-500/30 to-indigo-500/20 p-[2px]'>
-          <Avatar className='h-12 w-12 border border-slate-900'>
+    <div className='sticky top-24 flex flex-col gap-6 rounded-[2.5rem] border border-[rgba(0,0,0,0.05)] bg-white/75 p-6 text-[#4a4a4a] shadow-[0_30px_70px_-50px_rgba(51,51,51,0.65)] backdrop-blur-xl'>
+      <div className='flex items-center gap-3 rounded-2xl border border-[rgba(0,0,0,0.04)] bg-white/85 p-4 shadow-[0_18px_40px_-38px_rgba(200,169,241,0.6)]'>
+        <Link to={`/profile/${user?._id}`} className='rounded-2xl bg-gradient-to-br from-[#c8a9f1]/30 via-[#e8d6c6]/40 to-[#f8c8a3]/30 p-[2px]'>
+          <Avatar className='h-12 w-12 border border-[rgba(0,0,0,0.05)] bg-white'>
             <AvatarImage src={user?.profilePicture} alt='post_image' />
             <AvatarFallback>CN</AvatarFallback>
           </Avatar>
         </Link>
         <div className='flex flex-col'>
-          <h1 className='text-sm font-semibold text-slate-100'>
+          <h1 className='text-sm font-semibold text-[#333333]'>
             <Link to={`/profile/${user?._id}`}>{user?.username}</Link>
           </h1>
-          <span className='text-xs text-slate-400'>{user?.bio || 'Share a glimpse of your world today.'}</span>
+          <span className='text-xs text-[#6f6f6f]'>{user?.bio || 'Share a glimpse of your world today.'}</span>
         </div>
       </div>
-      <div className='rounded-2xl border border-slate-800/60 bg-gradient-to-br from-sky-500/10 via-transparent to-emerald-400/10 p-5 text-xs text-slate-200 shadow-inner shadow-sky-500/10'>
+      <div className='rounded-2xl border border-[rgba(0,0,0,0.04)] bg-gradient-to-br from-[#fbf7ff] via-white to-[#fff5ed] p-5 text-xs text-[#4a4a4a] shadow-[0_22px_45px_-40px_rgba(200,169,241,0.6)]'>
         <div className='flex items-start gap-3'>
-          <span className='rounded-2xl bg-slate-950/60 p-2 text-emerald-300'>
+          <span className='rounded-2xl bg-[#c8a9f1]/20 p-2 text-[#c8a9f1]'>
             <Sparkles className='h-4 w-4' />
           </span>
           <div className='space-y-1'>
-            <p className='text-sm font-semibold text-slate-100'>Creator cues</p>
+            <p className='text-sm font-semibold text-[#333333]'>Creator cues</p>
             <p>Drop a reel or story to stay on top of the community radar.</p>
           </div>
         </div>

--- a/frontend/src/components/RightSidebar.jsx
+++ b/frontend/src/components/RightSidebar.jsx
@@ -3,7 +3,6 @@ import { useSelector } from 'react-redux'
 import { Link } from 'react-router-dom'
 import SuggestedUsers from './SuggestedUsers'
 import FollowRequests from './FollowRequests'
-import { Sparkles } from 'lucide-react'
 
 const RightSidebar = () => {
   const { user } = useSelector(store => store.auth)
@@ -20,18 +19,9 @@ const RightSidebar = () => {
           <h1 className='text-sm font-semibold text-[var(--color-text)]'>
             <Link to={`/profile/${user?._id}`}>{user?.username}</Link>
           </h1>
-          <span className='text-xs text-[var(--color-text-muted)]'>{user?.bio || 'Share a glimpse of your world today.'}</span>
-        </div>
-      </div>
-      <div className='rounded-lg border border-[var(--color-outline)] bg-[var(--color-surface)] p-4 text-xs text-[var(--color-text-muted)]'>
-        <div className='flex items-start gap-3'>
-          <span className='flex h-9 w-9 items-center justify-center rounded-md bg-[var(--color-primary-start)]/15 text-[var(--color-primary-start)]'>
-            <Sparkles className='h-4 w-4' />
-          </span>
-          <div className='space-y-1'>
-            <p className='text-sm font-semibold text-[var(--color-text)]'>Creator cues</p>
-            <p>Drop a reel or story to stay on top of the community radar.</p>
-          </div>
+          {user?.bio ? (
+            <span className='text-xs text-[var(--color-text-muted)]'>{user.bio}</span>
+          ) : null}
         </div>
       </div>
       <SuggestedUsers />

--- a/frontend/src/components/RightSidebar.jsx
+++ b/frontend/src/components/RightSidebar.jsx
@@ -8,28 +8,28 @@ import { Sparkles } from 'lucide-react'
 const RightSidebar = () => {
   const { user } = useSelector(store => store.auth)
   return (
-    <div className='sticky top-24 flex flex-col gap-6 rounded-[2.5rem] border border-[rgba(0,0,0,0.05)] bg-white/75 p-6 text-[#4a4a4a] shadow-[0_30px_70px_-50px_rgba(51,51,51,0.65)] backdrop-blur-xl'>
-      <div className='flex items-center gap-3 rounded-2xl border border-[rgba(0,0,0,0.04)] bg-white/85 p-4 shadow-[0_18px_40px_-38px_rgba(200,169,241,0.6)]'>
-        <Link to={`/profile/${user?._id}`} className='rounded-2xl bg-gradient-to-br from-[#c8a9f1]/30 via-[#e8d6c6]/40 to-[#f8c8a3]/30 p-[2px]'>
-          <Avatar className='h-12 w-12 border border-[rgba(0,0,0,0.05)] bg-white'>
+    <div className='sticky top-24 flex flex-col gap-5 rounded-xl border border-[var(--color-outline)] bg-[var(--color-surface-raised)] p-5 text-[var(--color-text-muted)] shadow-[0_18px_34px_rgba(0,0,0,0.08)]'>
+      <div className='flex items-center gap-3 rounded-lg border border-[var(--color-outline)] bg-[var(--color-surface)] px-4 py-3'>
+        <Link to={`/profile/${user?._id}`} className='flex h-12 w-12 items-center justify-center rounded-md bg-[var(--color-primary-start)]/15'>
+          <Avatar className='h-10 w-10 border border-[var(--color-outline)] bg-[var(--color-surface-raised)]'>
             <AvatarImage src={user?.profilePicture} alt='post_image' />
             <AvatarFallback>CN</AvatarFallback>
           </Avatar>
         </Link>
         <div className='flex flex-col'>
-          <h1 className='text-sm font-semibold text-[#333333]'>
+          <h1 className='text-sm font-semibold text-[var(--color-text)]'>
             <Link to={`/profile/${user?._id}`}>{user?.username}</Link>
           </h1>
-          <span className='text-xs text-[#6f6f6f]'>{user?.bio || 'Share a glimpse of your world today.'}</span>
+          <span className='text-xs text-[var(--color-text-muted)]'>{user?.bio || 'Share a glimpse of your world today.'}</span>
         </div>
       </div>
-      <div className='rounded-2xl border border-[rgba(0,0,0,0.04)] bg-gradient-to-br from-[#fbf7ff] via-white to-[#fff5ed] p-5 text-xs text-[#4a4a4a] shadow-[0_22px_45px_-40px_rgba(200,169,241,0.6)]'>
+      <div className='rounded-lg border border-[var(--color-outline)] bg-[var(--color-surface)] p-4 text-xs text-[var(--color-text-muted)]'>
         <div className='flex items-start gap-3'>
-          <span className='rounded-2xl bg-[#c8a9f1]/20 p-2 text-[#c8a9f1]'>
+          <span className='flex h-9 w-9 items-center justify-center rounded-md bg-[var(--color-primary-start)]/15 text-[var(--color-primary-start)]'>
             <Sparkles className='h-4 w-4' />
           </span>
           <div className='space-y-1'>
-            <p className='text-sm font-semibold text-[#333333]'>Creator cues</p>
+            <p className='text-sm font-semibold text-[var(--color-text)]'>Creator cues</p>
             <p>Drop a reel or story to stay on top of the community radar.</p>
           </div>
         </div>

--- a/frontend/src/components/Search.jsx
+++ b/frontend/src/components/Search.jsx
@@ -52,25 +52,25 @@ const Search = () => {
   }, [normalizedQuery, reels])
 
   return (
-    <div className='mx-auto flex w-full max-w-5xl flex-col gap-8 rounded-[2.5rem] border border-slate-800/60 bg-slate-900/60 p-8 shadow-xl shadow-sky-500/10 backdrop-blur-xl'>
+    <div className='mx-auto flex w-full max-w-5xl flex-col gap-8 rounded-[2.5rem] border border-[rgba(0,0,0,0.05)] bg-white/80 p-8 text-[#4a4a4a] shadow-[0_32px_80px_-60px_rgba(51,51,51,0.6)] backdrop-blur-xl'>
       <div className='space-y-3'>
-        <h1 className='text-2xl font-semibold text-slate-50'>Search NovaSphere</h1>
-        <p className='text-sm text-slate-400'>Find creators, communities, and posts tailored to your vibe.</p>
+        <h1 className='text-2xl font-semibold text-[#333333]'>Search NovaSphere</h1>
+        <p className='text-sm text-[#6f6f6f]'>Find creators, communities, and posts tailored to your vibe.</p>
         <div className='relative'>
-          <SearchIcon className='absolute left-4 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-500' />
+          <SearchIcon className='absolute left-4 top-1/2 h-4 w-4 -translate-y-1/2 text-[#b8b8b8]' />
           <Input
             value={query}
             onChange={(event) => setQuery(event.target.value)}
             placeholder='Search for people or captions'
-            className='h-12 rounded-full border-slate-800/80 bg-slate-950/60 pl-11 text-slate-100 placeholder:text-slate-500'
+            className='h-12 rounded-full border-[rgba(0,0,0,0.06)] bg-white/90 pl-11 text-[#333333] placeholder:text-[#b8b8b8]'
           />
         </div>
       </div>
 
       <section className='grid gap-10 lg:grid-cols-[260px_1fr]'>
-        <div className='space-y-5 rounded-3xl border border-slate-800/50 bg-slate-950/40 p-5'>
-          <div className='flex items-center justify-between text-xs uppercase tracking-wide text-slate-500'>
-            <span className='font-semibold text-slate-200'>People</span>
+        <div className='space-y-5 rounded-3xl border border-[rgba(0,0,0,0.05)] bg-white/75 p-5 shadow-[0_24px_60px_-52px_rgba(51,51,51,0.45)]'>
+          <div className='flex items-center justify-between text-xs uppercase tracking-wide text-[#8c8c8c]'>
+            <span className='font-semibold text-[#4a4a4a]'>People</span>
             <span>{matchingPeople.length} results</span>
           </div>
           <div className='flex flex-col gap-3'>
@@ -79,20 +79,20 @@ const Search = () => {
                 <Link
                   key={person._id}
                   to={`/profile/${person._id}`}
-                  className='group flex items-center gap-3 rounded-2xl border border-transparent px-3 py-2 transition hover:border-slate-800/70 hover:bg-slate-900/60'
+                  className='group flex items-center gap-3 rounded-2xl border border-transparent px-3 py-2 transition hover:border-[rgba(0,0,0,0.08)] hover:bg-white'
                 >
-                  <Avatar className='h-10 w-10 border border-slate-900'>
+                  <Avatar className='h-10 w-10 border border-[rgba(0,0,0,0.05)] bg-white'>
                     <AvatarImage src={person.profilePicture} alt={person.username} />
                     <AvatarFallback>{person.username?.slice(0, 2)?.toUpperCase() || 'NS'}</AvatarFallback>
                   </Avatar>
                   <div className='flex flex-col'>
-                    <span className='text-sm font-medium text-slate-100 group-hover:text-slate-50'>{person.username}</span>
-                    <span className='text-xs text-slate-400'>{person.bio || 'New to the community'}</span>
+                    <span className='text-sm font-medium text-[#333333] group-hover:text-[#4a4a4a]'>{person.username}</span>
+                    <span className='text-xs text-[#8c8c8c]'>{person.bio || 'New to the community'}</span>
                   </div>
                 </Link>
               ))
             ) : (
-              <div className='rounded-2xl border border-slate-800/60 bg-slate-950/50 px-4 py-6 text-center text-sm text-slate-500'>
+              <div className='rounded-2xl border border-[rgba(0,0,0,0.05)] bg-white/70 px-4 py-6 text-center text-sm text-[#6f6f6f] shadow-[0_20px_45px_-40px_rgba(51,51,51,0.4)]'>
                 No people matched your search yet. Try a different name or keyword.
               </div>
             )}
@@ -100,8 +100,8 @@ const Search = () => {
         </div>
 
         <div className='space-y-5'>
-          <div className='flex items-center justify-between text-xs uppercase tracking-wide text-slate-500'>
-            <span className='font-semibold text-slate-200'>Posts & captions</span>
+          <div className='flex items-center justify-between text-xs uppercase tracking-wide text-[#8c8c8c]'>
+            <span className='font-semibold text-[#4a4a4a]'>Posts & captions</span>
             <span>{matchingPosts.length} results</span>
           </div>
           {matchingPosts.length ? (
@@ -109,35 +109,35 @@ const Search = () => {
               {matchingPosts.map(post => (
                 <article
                   key={post._id}
-                  className='group flex flex-col overflow-hidden rounded-3xl border border-slate-800/60 bg-slate-950/50 shadow-lg shadow-sky-500/10 transition hover:border-slate-700 hover:shadow-sky-500/20'
+                  className='group flex flex-col overflow-hidden rounded-3xl border border-[rgba(0,0,0,0.05)] bg-white/80 shadow-[0_28px_60px_-48px_rgba(51,51,51,0.55)] transition hover:border-[rgba(0,0,0,0.08)] hover:shadow-[0_32px_72px_-50px_rgba(200,169,241,0.6)]'
                 >
                   <Link to={`/p/${post._id}`} className='relative block'>
                     <img src={post.image} alt={post.caption} className='aspect-square w-full object-cover' />
-                    <div className='pointer-events-none absolute inset-0 bg-gradient-to-t from-slate-950/70 via-transparent to-transparent opacity-0 transition group-hover:opacity-100' />
+                    <div className='pointer-events-none absolute inset-0 bg-gradient-to-t from-black/45 via-transparent to-transparent opacity-0 transition group-hover:opacity-100' />
                   </Link>
                   <div className='flex flex-1 flex-col gap-3 p-4'>
                     <div className='flex items-center gap-3'>
-                      <Avatar className='h-9 w-9 border border-slate-900/80'>
+                      <Avatar className='h-9 w-9 border border-[rgba(0,0,0,0.05)] bg-white'>
                         <AvatarImage src={post.author?.profilePicture} alt={post.author?.username} />
                         <AvatarFallback>{post.author?.username?.slice(0, 2)?.toUpperCase() || 'NS'}</AvatarFallback>
                       </Avatar>
                       <div className='flex flex-col'>
-                        <span className='text-sm font-semibold text-slate-100'>{post.author?.username}</span>
-                        <span className='text-xs text-slate-500'>{new Date(post.createdAt).toLocaleDateString()}</span>
+                        <span className='text-sm font-semibold text-[#333333]'>{post.author?.username}</span>
+                        <span className='text-xs text-[#8c8c8c]'>{new Date(post.createdAt).toLocaleDateString()}</span>
                       </div>
                     </div>
-                    <p className='text-sm leading-5 text-slate-300'>{post.caption || 'Shared a new moment'}</p>
+                    <p className='text-sm leading-5 text-[#4a4a4a]'>{post.caption || 'Shared a new moment'}</p>
                     <div className='mt-auto flex flex-wrap gap-2'>
                       <Button
                         variant='secondary'
-                        className='rounded-full border-slate-800/70 bg-slate-900/60 text-slate-200 hover:border-slate-700 hover:bg-slate-900'
+                        className='rounded-full bg-[#e8d6c6] text-[#4a4a4a] hover:bg-[#ddc4b0]'
                         asChild
                       >
                         <Link to={`/p/${post._id}`}>View post</Link>
                       </Button>
                       <Button
                         variant='ghost'
-                        className='rounded-full border border-transparent text-slate-300 hover:border-slate-700/80 hover:bg-slate-900/60'
+                        className='rounded-full border border-transparent text-[#6f6f6f] hover:text-[#333333]'
                         asChild
                       >
                         <Link to={`/profile/${post.author?._id}`}>View profile</Link>
@@ -148,16 +148,16 @@ const Search = () => {
               ))}
             </div>
           ) : (
-            <div className='rounded-3xl border border-slate-800/60 bg-slate-950/50 p-10 text-center text-sm text-slate-500'>
+            <div className='rounded-3xl border border-[rgba(0,0,0,0.05)] bg-white/70 p-10 text-center text-sm text-[#6f6f6f] shadow-[0_24px_60px_-48px_rgba(51,51,51,0.45)]'>
               No posts matched your search. Try different keywords or explore trending topics.
             </div>
           )}
         </div>
       </section>
 
-      <section className='space-y-5 rounded-3xl border border-slate-800/60 bg-slate-950/40 p-6'>
-        <div className='flex items-center justify-between text-xs uppercase tracking-wide text-slate-500'>
-          <span className='font-semibold text-slate-200'>Reels</span>
+      <section className='space-y-5 rounded-3xl border border-[rgba(0,0,0,0.05)] bg-white/75 p-6 shadow-[0_24px_60px_-52px_rgba(51,51,51,0.45)]'>
+        <div className='flex items-center justify-between text-xs uppercase tracking-wide text-[#8c8c8c]'>
+          <span className='font-semibold text-[#4a4a4a]'>Reels</span>
           <span>{matchingReels.length} results</span>
         </div>
         {matchingReels.length ? (
@@ -167,7 +167,7 @@ const Search = () => {
                 key={reel._id}
                 type='button'
                 onClick={() => setActiveReel(reel)}
-                className='group overflow-hidden rounded-3xl border border-violet-500/30 bg-slate-950/60 shadow-lg shadow-violet-500/20 transition hover:border-violet-400/40 hover:shadow-violet-500/40'
+                className='group overflow-hidden rounded-3xl border border-[rgba(200,169,241,0.4)] bg-white/80 shadow-[0_28px_60px_-48px_rgba(200,169,241,0.45)] transition hover:border-[#c8a9f1]/60 hover:shadow-[0_32px_72px_-46px_rgba(200,169,241,0.65)]'
               >
                 <div className='relative'>
                   <video
@@ -177,18 +177,18 @@ const Search = () => {
                     playsInline
                     className='aspect-[9/16] w-full object-cover'
                   />
-                  <div className='absolute inset-0 flex flex-col justify-between bg-gradient-to-t from-slate-950/80 via-transparent to-transparent p-4 opacity-0 transition group-hover:opacity-100'>
+                  <div className='absolute inset-0 flex flex-col justify-between bg-gradient-to-t from-black/55 via-transparent to-transparent p-4 opacity-0 transition group-hover:opacity-100'>
                     <div className='flex items-center gap-3'>
-                      <Avatar className='h-8 w-8 border border-slate-900/80'>
+                      <Avatar className='h-8 w-8 border border-[rgba(255,255,255,0.6)]'>
                         <AvatarImage src={reel.author?.profilePicture} alt={reel.author?.username} />
                         <AvatarFallback>{reel.author?.username?.slice(0, 2)?.toUpperCase() || 'NS'}</AvatarFallback>
                       </Avatar>
                       <div className='flex flex-col text-left'>
-                        <span className='text-xs font-semibold text-slate-50'>{reel.author?.username}</span>
-                        <span className='text-[11px] text-slate-400'>{reel.views?.length || 0} views</span>
+                        <span className='text-xs font-semibold text-white'>{reel.author?.username}</span>
+                        <span className='text-[11px] text-white/80'>{reel.views?.length || 0} views</span>
                       </div>
                     </div>
-                    <span className='inline-flex items-center gap-2 self-end rounded-full bg-violet-500/20 px-3 py-1 text-[11px] font-semibold uppercase tracking-wide text-violet-200'>
+                    <span className='inline-flex items-center gap-2 self-end rounded-full bg-white/30 px-3 py-1 text-[11px] font-semibold uppercase tracking-wide text-white'>
                       <PlayCircle className='h-3.5 w-3.5' />
                       Watch
                     </span>
@@ -198,16 +198,16 @@ const Search = () => {
             ))}
           </div>
         ) : (
-          <div className='rounded-2xl border border-slate-800/60 bg-slate-950/60 p-8 text-center text-sm text-slate-500'>
+          <div className='rounded-2xl border border-[rgba(0,0,0,0.05)] bg-white/70 p-8 text-center text-sm text-[#6f6f6f] shadow-[0_22px_50px_-46px_rgba(51,51,51,0.45)]'>
             No reels match that search yet. Try another creator or vibe.
           </div>
         )}
       </section>
 
       {!normalizedQuery && user && (
-        <div className='rounded-3xl border border-slate-800/60 bg-gradient-to-r from-sky-500/10 via-emerald-400/5 to-indigo-500/10 p-6 text-sm text-slate-300'>
-          <h2 className='text-base font-semibold text-slate-100'>Search tips</h2>
-          <ul className='mt-3 grid gap-2 text-xs text-slate-400 sm:grid-cols-2'>
+        <div className='rounded-3xl border border-[rgba(0,0,0,0.05)] bg-gradient-to-r from-[#c8a9f1]/20 via-[#e8d6c6]/25 to-[#f8c8a3]/20 p-6 text-sm text-[#4a4a4a] shadow-[0_24px_60px_-52px_rgba(200,169,241,0.45)]'>
+          <h2 className='text-base font-semibold text-[#333333]'>Search tips</h2>
+          <ul className='mt-3 grid gap-2 text-xs text-[#6f6f6f] sm:grid-cols-2'>
             <li>Look up friends by their @handle or name.</li>
             <li>Search captions to revisit moments you loved.</li>
             <li>Use broad words like &ldquo;travel&rdquo; or &ldquo;design&rdquo; to find inspiration.</li>

--- a/frontend/src/components/Search.jsx
+++ b/frontend/src/components/Search.jsx
@@ -52,25 +52,25 @@ const Search = () => {
   }, [normalizedQuery, reels])
 
   return (
-    <div className='mx-auto flex w-full max-w-5xl flex-col gap-8 rounded-[2.5rem] border border-[rgba(0,0,0,0.05)] bg-white/80 p-8 text-[#4a4a4a] shadow-[0_32px_80px_-60px_rgba(51,51,51,0.6)] backdrop-blur-xl'>
+    <div className='mx-auto flex w-full max-w-5xl flex-col gap-8 rounded-[2.5rem] border border-[rgba(0,0,0,0.05)] bg-white/80 p-8 text-[var(--color-text-muted)] shadow-[0_32px_80px_-60px_rgba(51,51,51,0.6)] backdrop-blur-xl'>
       <div className='space-y-3'>
-        <h1 className='text-2xl font-semibold text-[#333333]'>Search NovaSphere</h1>
-        <p className='text-sm text-[#6f6f6f]'>Find creators, communities, and posts tailored to your vibe.</p>
+        <h1 className='text-2xl font-semibold text-[var(--color-text)]'>Search Let&apos;s Talk</h1>
+        <p className='text-sm text-[var(--color-text-muted)]'>Find creators, communities, and posts tailored to your vibe.</p>
         <div className='relative'>
           <SearchIcon className='absolute left-4 top-1/2 h-4 w-4 -translate-y-1/2 text-[#b8b8b8]' />
           <Input
             value={query}
             onChange={(event) => setQuery(event.target.value)}
             placeholder='Search for people or captions'
-            className='h-12 rounded-full border-[rgba(0,0,0,0.06)] bg-white/90 pl-11 text-[#333333] placeholder:text-[#b8b8b8]'
+            className='h-12 rounded-full border-[rgba(0,0,0,0.06)] bg-white/90 pl-11 text-[var(--color-text)] placeholder:text-[#9a9a9a]'
           />
         </div>
       </div>
 
       <section className='grid gap-10 lg:grid-cols-[260px_1fr]'>
         <div className='space-y-5 rounded-3xl border border-[rgba(0,0,0,0.05)] bg-white/75 p-5 shadow-[0_24px_60px_-52px_rgba(51,51,51,0.45)]'>
-          <div className='flex items-center justify-between text-xs uppercase tracking-wide text-[#8c8c8c]'>
-            <span className='font-semibold text-[#4a4a4a]'>People</span>
+          <div className='flex items-center justify-between text-xs uppercase tracking-wide text-[#5a5a5a]'>
+            <span className='font-semibold text-[var(--color-text)]'>People</span>
             <span>{matchingPeople.length} results</span>
           </div>
           <div className='flex flex-col gap-3'>
@@ -86,13 +86,13 @@ const Search = () => {
                     <AvatarFallback>{person.username?.slice(0, 2)?.toUpperCase() || 'NS'}</AvatarFallback>
                   </Avatar>
                   <div className='flex flex-col'>
-                    <span className='text-sm font-medium text-[#333333] group-hover:text-[#4a4a4a]'>{person.username}</span>
-                    <span className='text-xs text-[#8c8c8c]'>{person.bio || 'New to the community'}</span>
+                    <span className='text-sm font-medium text-[var(--color-text)] group-hover:text-[#2c2c2c]'>{person.username}</span>
+                    <span className='text-xs text-[#5f5f5f]'>{person.bio || 'New to the community'}</span>
                   </div>
                 </Link>
               ))
             ) : (
-              <div className='rounded-2xl border border-[rgba(0,0,0,0.05)] bg-white/70 px-4 py-6 text-center text-sm text-[#6f6f6f] shadow-[0_20px_45px_-40px_rgba(51,51,51,0.4)]'>
+              <div className='rounded-2xl border border-[rgba(0,0,0,0.05)] bg-white/70 px-4 py-6 text-center text-sm text-[var(--color-text-muted)] shadow-[0_20px_45px_-40px_rgba(51,51,51,0.4)]'>
                 No people matched your search yet. Try a different name or keyword.
               </div>
             )}
@@ -100,8 +100,8 @@ const Search = () => {
         </div>
 
         <div className='space-y-5'>
-          <div className='flex items-center justify-between text-xs uppercase tracking-wide text-[#8c8c8c]'>
-            <span className='font-semibold text-[#4a4a4a]'>Posts & captions</span>
+          <div className='flex items-center justify-between text-xs uppercase tracking-wide text-[#5a5a5a]'>
+            <span className='font-semibold text-[var(--color-text)]'>Posts & captions</span>
             <span>{matchingPosts.length} results</span>
           </div>
           {matchingPosts.length ? (
@@ -122,11 +122,11 @@ const Search = () => {
                         <AvatarFallback>{post.author?.username?.slice(0, 2)?.toUpperCase() || 'NS'}</AvatarFallback>
                       </Avatar>
                       <div className='flex flex-col'>
-                        <span className='text-sm font-semibold text-[#333333]'>{post.author?.username}</span>
-                        <span className='text-xs text-[#8c8c8c]'>{new Date(post.createdAt).toLocaleDateString()}</span>
+                        <span className='text-sm font-semibold text-[var(--color-text)]'>{post.author?.username}</span>
+                        <span className='text-xs text-[#5f5f5f]'>{new Date(post.createdAt).toLocaleDateString()}</span>
                       </div>
                     </div>
-                    <p className='text-sm leading-5 text-[#4a4a4a]'>{post.caption || 'Shared a new moment'}</p>
+                    <p className='text-sm leading-5 text-[var(--color-text-muted)]'>{post.caption || 'Shared a new moment'}</p>
                     <div className='mt-auto flex flex-wrap gap-2'>
                       <Button
                         variant='secondary'
@@ -148,7 +148,7 @@ const Search = () => {
               ))}
             </div>
           ) : (
-            <div className='rounded-3xl border border-[rgba(0,0,0,0.05)] bg-white/70 p-10 text-center text-sm text-[#6f6f6f] shadow-[0_24px_60px_-48px_rgba(51,51,51,0.45)]'>
+            <div className='rounded-3xl border border-[rgba(0,0,0,0.05)] bg-white/70 p-10 text-center text-sm text-[var(--color-text-muted)] shadow-[0_24px_60px_-48px_rgba(51,51,51,0.45)]'>
               No posts matched your search. Try different keywords or explore trending topics.
             </div>
           )}
@@ -156,8 +156,8 @@ const Search = () => {
       </section>
 
       <section className='space-y-5 rounded-3xl border border-[rgba(0,0,0,0.05)] bg-white/75 p-6 shadow-[0_24px_60px_-52px_rgba(51,51,51,0.45)]'>
-        <div className='flex items-center justify-between text-xs uppercase tracking-wide text-[#8c8c8c]'>
-          <span className='font-semibold text-[#4a4a4a]'>Reels</span>
+        <div className='flex items-center justify-between text-xs uppercase tracking-wide text-[#5a5a5a]'>
+          <span className='font-semibold text-[var(--color-text)]'>Reels</span>
           <span>{matchingReels.length} results</span>
         </div>
         {matchingReels.length ? (
@@ -205,9 +205,9 @@ const Search = () => {
       </section>
 
       {!normalizedQuery && user && (
-        <div className='rounded-3xl border border-[rgba(0,0,0,0.05)] bg-gradient-to-r from-[#c8a9f1]/20 via-[#e8d6c6]/25 to-[#f8c8a3]/20 p-6 text-sm text-[#4a4a4a] shadow-[0_24px_60px_-52px_rgba(200,169,241,0.45)]'>
-          <h2 className='text-base font-semibold text-[#333333]'>Search tips</h2>
-          <ul className='mt-3 grid gap-2 text-xs text-[#6f6f6f] sm:grid-cols-2'>
+        <div className='rounded-3xl border border-[rgba(0,0,0,0.05)] bg-gradient-to-r from-[#c8a9f1]/20 via-[#e8d6c6]/25 to-[#f8c8a3]/20 p-6 text-sm text-[var(--color-text-muted)] shadow-[0_24px_60px_-52px_rgba(200,169,241,0.45)]'>
+          <h2 className='text-base font-semibold text-[var(--color-text)]'>Search tips</h2>
+          <ul className='mt-3 grid gap-2 text-xs text-[#545454] sm:grid-cols-2'>
             <li>Look up friends by their @handle or name.</li>
             <li>Search captions to revisit moments you loved.</li>
             <li>Use broad words like &ldquo;travel&rdquo; or &ldquo;design&rdquo; to find inspiration.</li>

--- a/frontend/src/components/Search.jsx
+++ b/frontend/src/components/Search.jsx
@@ -1,0 +1,150 @@
+import { useMemo, useState } from 'react'
+import { useSelector } from 'react-redux'
+import useGetAllPost from '@/hooks/useGetAllPost'
+import useGetSuggestedUsers from '@/hooks/useGetSuggestedUsers'
+import { Input } from './ui/input'
+import { Avatar, AvatarFallback, AvatarImage } from './ui/avatar'
+import { Button } from './ui/button'
+import { Link } from 'react-router-dom'
+import { Search as SearchIcon } from 'lucide-react'
+
+const Search = () => {
+  useGetAllPost()
+  useGetSuggestedUsers()
+
+  const [query, setQuery] = useState('')
+  const { posts } = useSelector(store => store.post)
+  const { suggestedUsers, user } = useSelector(store => store.auth)
+
+  const normalizedQuery = query.trim().toLowerCase()
+
+  const matchingPeople = useMemo(() => {
+    if (!normalizedQuery) return suggestedUsers
+    const haystack = suggestedUsers || []
+    return haystack.filter(person => {
+      const username = person?.username?.toLowerCase() || ''
+      const bio = person?.bio?.toLowerCase() || ''
+      return username.includes(normalizedQuery) || bio.includes(normalizedQuery)
+    })
+  }, [normalizedQuery, suggestedUsers])
+
+  const matchingPosts = useMemo(() => {
+    if (!normalizedQuery) return posts
+    return posts.filter(post => {
+      const caption = post?.caption?.toLowerCase() || ''
+      const author = post?.author?.username?.toLowerCase() || ''
+      return caption.includes(normalizedQuery) || author.includes(normalizedQuery)
+    })
+  }, [normalizedQuery, posts])
+
+  return (
+    <div className='mx-auto flex w-full max-w-5xl flex-col gap-8 rounded-[2.5rem] border border-slate-800/60 bg-slate-900/60 p-8 shadow-xl shadow-sky-500/10 backdrop-blur-xl'>
+      <div className='space-y-3'>
+        <h1 className='text-2xl font-semibold text-slate-50'>Search NovaSphere</h1>
+        <p className='text-sm text-slate-400'>Find creators, communities, and posts tailored to your vibe.</p>
+        <div className='relative'>
+          <SearchIcon className='absolute left-4 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-500' />
+          <Input
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder='Search for people or captions'
+            className='h-12 rounded-full border-slate-800/80 bg-slate-950/60 pl-11 text-slate-100 placeholder:text-slate-500'
+          />
+        </div>
+      </div>
+
+      <section className='grid gap-10 lg:grid-cols-[260px_1fr]'>
+        <div className='space-y-5 rounded-3xl border border-slate-800/50 bg-slate-950/40 p-5'>
+          <div className='flex items-center justify-between text-xs uppercase tracking-wide text-slate-500'>
+            <span className='font-semibold text-slate-200'>People</span>
+            <span>{matchingPeople.length} results</span>
+          </div>
+          <div className='flex flex-col gap-3'>
+            {matchingPeople.length ? (
+              matchingPeople.map(person => (
+                <Link
+                  key={person._id}
+                  to={`/profile/${person._id}`}
+                  className='group flex items-center gap-3 rounded-2xl border border-transparent px-3 py-2 transition hover:border-slate-800/70 hover:bg-slate-900/60'
+                >
+                  <Avatar className='h-10 w-10 border border-slate-900'>
+                    <AvatarImage src={person.profilePicture} alt={person.username} />
+                    <AvatarFallback>{person.username?.slice(0, 2)?.toUpperCase() || 'NS'}</AvatarFallback>
+                  </Avatar>
+                  <div className='flex flex-col'>
+                    <span className='text-sm font-medium text-slate-100 group-hover:text-slate-50'>{person.username}</span>
+                    <span className='text-xs text-slate-400'>{person.bio || 'New to the community'}</span>
+                  </div>
+                </Link>
+              ))
+            ) : (
+              <div className='rounded-2xl border border-slate-800/60 bg-slate-950/50 px-4 py-6 text-center text-sm text-slate-500'>
+                No people matched your search yet. Try a different name or keyword.
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className='space-y-5'>
+          <div className='flex items-center justify-between text-xs uppercase tracking-wide text-slate-500'>
+            <span className='font-semibold text-slate-200'>Posts & captions</span>
+            <span>{matchingPosts.length} results</span>
+          </div>
+          {matchingPosts.length ? (
+            <div className='grid gap-4 sm:grid-cols-2'>
+              {matchingPosts.map(post => (
+                <article
+                  key={post._id}
+                  className='group flex flex-col overflow-hidden rounded-3xl border border-slate-800/60 bg-slate-950/50 shadow-lg shadow-sky-500/10 transition hover:border-slate-700 hover:shadow-sky-500/20'
+                >
+                  <div className='relative'>
+                    <img src={post.image} alt={post.caption} className='aspect-square w-full object-cover' />
+                    <div className='pointer-events-none absolute inset-0 bg-gradient-to-t from-slate-950/70 via-transparent to-transparent opacity-0 transition group-hover:opacity-100' />
+                  </div>
+                  <div className='flex flex-1 flex-col gap-3 p-4'>
+                    <div className='flex items-center gap-3'>
+                      <Avatar className='h-9 w-9 border border-slate-900/80'>
+                        <AvatarImage src={post.author?.profilePicture} alt={post.author?.username} />
+                        <AvatarFallback>{post.author?.username?.slice(0, 2)?.toUpperCase() || 'NS'}</AvatarFallback>
+                      </Avatar>
+                      <div className='flex flex-col'>
+                        <span className='text-sm font-semibold text-slate-100'>{post.author?.username}</span>
+                        <span className='text-xs text-slate-500'>{new Date(post.createdAt).toLocaleDateString()}</span>
+                      </div>
+                    </div>
+                    <p className='text-sm leading-5 text-slate-300'>{post.caption || 'Shared a new moment'}</p>
+                    <Button
+                      variant='secondary'
+                      className='mt-auto rounded-full border-slate-800/70 bg-slate-900/60 text-slate-200 hover:border-slate-700 hover:bg-slate-900'
+                      asChild
+                    >
+                      <Link to={`/profile/${post.author?._id}`}>View profile</Link>
+                    </Button>
+                  </div>
+                </article>
+              ))}
+            </div>
+          ) : (
+            <div className='rounded-3xl border border-slate-800/60 bg-slate-950/50 p-10 text-center text-sm text-slate-500'>
+              No posts matched your search. Try different keywords or explore trending topics.
+            </div>
+          )}
+        </div>
+      </section>
+
+      {!normalizedQuery && user && (
+        <div className='rounded-3xl border border-slate-800/60 bg-gradient-to-r from-sky-500/10 via-emerald-400/5 to-indigo-500/10 p-6 text-sm text-slate-300'>
+          <h2 className='text-base font-semibold text-slate-100'>Search tips</h2>
+          <ul className='mt-3 grid gap-2 text-xs text-slate-400 sm:grid-cols-2'>
+            <li>Look up friends by their @handle or name.</li>
+            <li>Search captions to revisit moments you loved.</li>
+            <li>Use broad words like &ldquo;travel&rdquo; or &ldquo;design&rdquo; to find inspiration.</li>
+            <li>Tap any result to jump straight into the conversation.</li>
+          </ul>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default Search

--- a/frontend/src/components/Search.jsx
+++ b/frontend/src/components/Search.jsx
@@ -2,18 +2,23 @@ import { useMemo, useState } from 'react'
 import { useSelector } from 'react-redux'
 import useGetAllPost from '@/hooks/useGetAllPost'
 import useGetSuggestedUsers from '@/hooks/useGetSuggestedUsers'
+import useReels from '@/hooks/useReels'
 import { Input } from './ui/input'
 import { Avatar, AvatarFallback, AvatarImage } from './ui/avatar'
 import { Button } from './ui/button'
 import { Link } from 'react-router-dom'
-import { Search as SearchIcon } from 'lucide-react'
+import { PlayCircle, Search as SearchIcon } from 'lucide-react'
+import ReelPlayerDialog from './ReelPlayerDialog'
 
 const Search = () => {
   useGetAllPost()
   useGetSuggestedUsers()
+  useReels()
 
   const [query, setQuery] = useState('')
+  const [activeReel, setActiveReel] = useState(null)
   const { posts } = useSelector(store => store.post)
+  const { reels } = useSelector(store => store.reel)
   const { suggestedUsers, user } = useSelector(store => store.auth)
 
   const normalizedQuery = query.trim().toLowerCase()
@@ -36,6 +41,15 @@ const Search = () => {
       return caption.includes(normalizedQuery) || author.includes(normalizedQuery)
     })
   }, [normalizedQuery, posts])
+
+  const matchingReels = useMemo(() => {
+    if (!normalizedQuery) return reels
+    return reels.filter(reel => {
+      const caption = reel?.caption?.toLowerCase() || ''
+      const author = reel?.author?.username?.toLowerCase() || ''
+      return caption.includes(normalizedQuery) || author.includes(normalizedQuery)
+    })
+  }, [normalizedQuery, reels])
 
   return (
     <div className='mx-auto flex w-full max-w-5xl flex-col gap-8 rounded-[2.5rem] border border-slate-800/60 bg-slate-900/60 p-8 shadow-xl shadow-sky-500/10 backdrop-blur-xl'>
@@ -97,10 +111,10 @@ const Search = () => {
                   key={post._id}
                   className='group flex flex-col overflow-hidden rounded-3xl border border-slate-800/60 bg-slate-950/50 shadow-lg shadow-sky-500/10 transition hover:border-slate-700 hover:shadow-sky-500/20'
                 >
-                  <div className='relative'>
+                  <Link to={`/p/${post._id}`} className='relative block'>
                     <img src={post.image} alt={post.caption} className='aspect-square w-full object-cover' />
                     <div className='pointer-events-none absolute inset-0 bg-gradient-to-t from-slate-950/70 via-transparent to-transparent opacity-0 transition group-hover:opacity-100' />
-                  </div>
+                  </Link>
                   <div className='flex flex-1 flex-col gap-3 p-4'>
                     <div className='flex items-center gap-3'>
                       <Avatar className='h-9 w-9 border border-slate-900/80'>
@@ -113,13 +127,22 @@ const Search = () => {
                       </div>
                     </div>
                     <p className='text-sm leading-5 text-slate-300'>{post.caption || 'Shared a new moment'}</p>
-                    <Button
-                      variant='secondary'
-                      className='mt-auto rounded-full border-slate-800/70 bg-slate-900/60 text-slate-200 hover:border-slate-700 hover:bg-slate-900'
-                      asChild
-                    >
-                      <Link to={`/profile/${post.author?._id}`}>View profile</Link>
-                    </Button>
+                    <div className='mt-auto flex flex-wrap gap-2'>
+                      <Button
+                        variant='secondary'
+                        className='rounded-full border-slate-800/70 bg-slate-900/60 text-slate-200 hover:border-slate-700 hover:bg-slate-900'
+                        asChild
+                      >
+                        <Link to={`/p/${post._id}`}>View post</Link>
+                      </Button>
+                      <Button
+                        variant='ghost'
+                        className='rounded-full border border-transparent text-slate-300 hover:border-slate-700/80 hover:bg-slate-900/60'
+                        asChild
+                      >
+                        <Link to={`/profile/${post.author?._id}`}>View profile</Link>
+                      </Button>
+                    </div>
                   </div>
                 </article>
               ))}
@@ -130,6 +153,55 @@ const Search = () => {
             </div>
           )}
         </div>
+      </section>
+
+      <section className='space-y-5 rounded-3xl border border-slate-800/60 bg-slate-950/40 p-6'>
+        <div className='flex items-center justify-between text-xs uppercase tracking-wide text-slate-500'>
+          <span className='font-semibold text-slate-200'>Reels</span>
+          <span>{matchingReels.length} results</span>
+        </div>
+        {matchingReels.length ? (
+          <div className='grid gap-4 sm:grid-cols-2 lg:grid-cols-3'>
+            {matchingReels.map(reel => (
+              <button
+                key={reel._id}
+                type='button'
+                onClick={() => setActiveReel(reel)}
+                className='group overflow-hidden rounded-3xl border border-violet-500/30 bg-slate-950/60 shadow-lg shadow-violet-500/20 transition hover:border-violet-400/40 hover:shadow-violet-500/40'
+              >
+                <div className='relative'>
+                  <video
+                    src={reel.videoUrl}
+                    muted
+                    loop
+                    playsInline
+                    className='aspect-[9/16] w-full object-cover'
+                  />
+                  <div className='absolute inset-0 flex flex-col justify-between bg-gradient-to-t from-slate-950/80 via-transparent to-transparent p-4 opacity-0 transition group-hover:opacity-100'>
+                    <div className='flex items-center gap-3'>
+                      <Avatar className='h-8 w-8 border border-slate-900/80'>
+                        <AvatarImage src={reel.author?.profilePicture} alt={reel.author?.username} />
+                        <AvatarFallback>{reel.author?.username?.slice(0, 2)?.toUpperCase() || 'NS'}</AvatarFallback>
+                      </Avatar>
+                      <div className='flex flex-col text-left'>
+                        <span className='text-xs font-semibold text-slate-50'>{reel.author?.username}</span>
+                        <span className='text-[11px] text-slate-400'>{reel.views?.length || 0} views</span>
+                      </div>
+                    </div>
+                    <span className='inline-flex items-center gap-2 self-end rounded-full bg-violet-500/20 px-3 py-1 text-[11px] font-semibold uppercase tracking-wide text-violet-200'>
+                      <PlayCircle className='h-3.5 w-3.5' />
+                      Watch
+                    </span>
+                  </div>
+                </div>
+              </button>
+            ))}
+          </div>
+        ) : (
+          <div className='rounded-2xl border border-slate-800/60 bg-slate-950/60 p-8 text-center text-sm text-slate-500'>
+            No reels match that search yet. Try another creator or vibe.
+          </div>
+        )}
       </section>
 
       {!normalizedQuery && user && (
@@ -143,6 +215,15 @@ const Search = () => {
           </ul>
         </div>
       )}
+      <ReelPlayerDialog
+        reel={activeReel}
+        open={Boolean(activeReel)}
+        onOpenChange={(open) => {
+          if (!open) {
+            setActiveReel(null)
+          }
+        }}
+      />
     </div>
   )
 }

--- a/frontend/src/components/StoriesBar.jsx
+++ b/frontend/src/components/StoriesBar.jsx
@@ -7,13 +7,13 @@ import StoryViewer from './StoryViewer'
 const StoryBubble = ({ story, label, onClick }) => {
   return (
     <button onClick={() => onClick(story)} className='flex flex-col items-center gap-2 focus:outline-none'>
-      <div className='rounded-full bg-gradient-to-tr from-sky-500 via-emerald-400 to-indigo-500 p-[2px] transition hover:scale-105'>
-        <Avatar className='h-16 w-16 border-4 border-slate-950/80'>
+      <div className='rounded-full bg-gradient-to-tr from-[#c8a9f1] via-[#e8d6c6] to-[#f8c8a3] p-[2px] transition hover:scale-105'>
+        <Avatar className='h-16 w-16 border-4 border-white/70 bg-white'>
           <AvatarImage src={story?.owner?.profilePicture} alt={story?.owner?.username} />
           <AvatarFallback>ST</AvatarFallback>
         </Avatar>
       </div>
-      <span className='text-xs text-slate-400'>{label}</span>
+      <span className='text-xs text-[#8c8c8c]'>{label}</span>
     </button>
   )
 }
@@ -35,18 +35,18 @@ const StoriesBar = () => {
   }
 
   return (
-    <div className='rounded-[2rem] border border-slate-800/60 bg-slate-900/60 p-6 shadow-xl shadow-sky-500/10 backdrop-blur-xl'>
+    <div className='rounded-[2rem] border border-[rgba(0,0,0,0.05)] bg-white/80 p-6 text-[#4a4a4a] shadow-[0_24px_60px_-48px_rgba(51,51,51,0.45)] backdrop-blur-xl'>
       <div className='mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between'>
         <div>
-          <h2 className='text-sm font-semibold text-slate-100'>Stories</h2>
-          <p className='text-xs text-slate-400'>Capture a 24-hour highlight for your circle.</p>
+          <h2 className='text-sm font-semibold text-[#333333]'>Stories</h2>
+          <p className='text-xs text-[#8c8c8c]'>Capture a 24-hour highlight for your circle.</p>
         </div>
         <div className='w-full sm:w-40'>
           <StoryComposer />
         </div>
       </div>
       {isLoading ? (
-        <div className='py-6 text-center text-sm text-slate-400'>Loading stories...</div>
+        <div className='py-6 text-center text-sm text-[#8c8c8c]'>Loading stories...</div>
       ) : (
         <div className='flex gap-4 overflow-x-auto pb-2'>
           {myStories.length > 0 ? (
@@ -59,8 +59,8 @@ const StoriesBar = () => {
               />
             ))
           ) : (
-            <div className='flex flex-col items-center justify-center text-xs text-slate-500'>
-              <Avatar className='mb-1 h-16 w-16 border border-slate-900'>
+            <div className='flex flex-col items-center justify-center text-xs text-[#8c8c8c]'>
+              <Avatar className='mb-1 h-16 w-16 border border-[rgba(0,0,0,0.05)] bg-white'>
                 <AvatarImage src={user?.profilePicture} />
                 <AvatarFallback>YOU</AvatarFallback>
               </Avatar>

--- a/frontend/src/components/StoriesBar.jsx
+++ b/frontend/src/components/StoriesBar.jsx
@@ -1,91 +1,85 @@
-import React, { useMemo, useState } from 'react';
-import { useSelector } from 'react-redux';
-import { Avatar, AvatarFallback, AvatarImage } from './ui/avatar';
-import StoryComposer from './StoryComposer';
-import StoryViewer from './StoryViewer';
+import { useMemo, useState } from 'react'
+import { useSelector } from 'react-redux'
+import { Avatar, AvatarFallback, AvatarImage } from './ui/avatar'
+import StoryComposer from './StoryComposer'
+import StoryViewer from './StoryViewer'
 
 const StoryBubble = ({ story, label, onClick }) => {
-    return (
-        <button onClick={() => onClick(story)} className='flex flex-col items-center gap-2 focus:outline-none'>
-            <div className='p-[2px] bg-gradient-to-tr from-pink-500 via-red-500 to-yellow-500 rounded-full'>
-                <Avatar className='h-16 w-16 border-4 border-white'>
-                    <AvatarImage src={story?.owner?.profilePicture} alt={story?.owner?.username} />
-                    <AvatarFallback>ST</AvatarFallback>
-                </Avatar>
-            </div>
-            <span className='text-xs text-gray-600'>{label}</span>
-        </button>
-    );
-};
+  return (
+    <button onClick={() => onClick(story)} className='flex flex-col items-center gap-2 focus:outline-none'>
+      <div className='rounded-full bg-gradient-to-tr from-sky-500 via-emerald-400 to-indigo-500 p-[2px] transition hover:scale-105'>
+        <Avatar className='h-16 w-16 border-4 border-slate-950/80'>
+          <AvatarImage src={story?.owner?.profilePicture} alt={story?.owner?.username} />
+          <AvatarFallback>ST</AvatarFallback>
+        </Avatar>
+      </div>
+      <span className='text-xs text-slate-400'>{label}</span>
+    </button>
+  )
+}
 
 const StoriesBar = () => {
-    const { myStories, stories, isLoading } = useSelector(store => store.story);
-    const { user } = useSelector(store => store.auth);
-    const [activeStory, setActiveStory] = useState(null);
-    const [viewerOpen, setViewerOpen] = useState(false);
+  const { myStories, stories, isLoading } = useSelector(store => store.story)
+  const { user } = useSelector(store => store.auth)
+  const [activeStory, setActiveStory] = useState(null)
+  const [viewerOpen, setViewerOpen] = useState(false)
 
-    const orderedStories = useMemo(() => {
-        return [...stories].sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
-    }, [stories]);
+  const orderedStories = useMemo(() => {
+    return [...stories].sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt))
+  }, [stories])
 
-    const openStory = (story) => {
-        if(!story) return;
-        setActiveStory(story);
-        setViewerOpen(true);
-    };
+  const openStory = (story) => {
+    if (!story) return
+    setActiveStory(story)
+    setViewerOpen(true)
+  }
 
-    return (
-        <div className='w-full bg-white border border-gray-200 rounded-2xl p-4 shadow-sm'>
-            <div className='flex items-center justify-between mb-3 gap-3'>
-                <div>
-                    <h2 className='font-semibold text-sm'>Stories</h2>
-                    <p className='text-xs text-gray-500'>Share what you are up to for 24 hours.</p>
-                </div>
-                <div className='w-40'>
-                    <StoryComposer />
-                </div>
-            </div>
-            {
-                isLoading ? (
-                    <div className='text-sm text-gray-500 py-6 text-center'>Loading stories...</div>
-                ) : (
-                    <div className='flex gap-4 overflow-x-auto pb-2'>
-                        {
-                            myStories.length > 0 ? (
-                                myStories.map((story) => (
-                                    <StoryBubble
-                                        key={story._id}
-                                        story={story}
-                                        label='Your story'
-                                        onClick={openStory}
-                                    />
-                                ))
-                            ) : (
-                                <div className='flex flex-col items-center justify-center text-xs text-gray-500'>
-                                    <Avatar className='h-16 w-16 mb-1'>
-                                        <AvatarImage src={user?.profilePicture} />
-                                        <AvatarFallback>YOU</AvatarFallback>
-                                    </Avatar>
-                                    <span>Create a story to share</span>
-                                </div>
-                            )
-                        }
-                        {
-                            orderedStories.map((story) => (
-                                <StoryBubble
-                                    key={story._id}
-                                    story={story}
-                                    label={story.owner?.username}
-                                    onClick={openStory}
-                                />
-                            ))
-                        }
-                    </div>
-                )
-            }
-            <StoryViewer story={activeStory} open={viewerOpen} onOpenChange={setViewerOpen} />
+  return (
+    <div className='rounded-[2rem] border border-slate-800/60 bg-slate-900/60 p-6 shadow-xl shadow-sky-500/10 backdrop-blur-xl'>
+      <div className='mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between'>
+        <div>
+          <h2 className='text-sm font-semibold text-slate-100'>Stories</h2>
+          <p className='text-xs text-slate-400'>Capture a 24-hour highlight for your circle.</p>
         </div>
-    );
-};
+        <div className='w-full sm:w-40'>
+          <StoryComposer />
+        </div>
+      </div>
+      {isLoading ? (
+        <div className='py-6 text-center text-sm text-slate-400'>Loading stories...</div>
+      ) : (
+        <div className='flex gap-4 overflow-x-auto pb-2'>
+          {myStories.length > 0 ? (
+            myStories.map((story) => (
+              <StoryBubble
+                key={story._id}
+                story={story}
+                label='Your story'
+                onClick={openStory}
+              />
+            ))
+          ) : (
+            <div className='flex flex-col items-center justify-center text-xs text-slate-500'>
+              <Avatar className='mb-1 h-16 w-16 border border-slate-900'>
+                <AvatarImage src={user?.profilePicture} />
+                <AvatarFallback>YOU</AvatarFallback>
+              </Avatar>
+              <span>Create a story to share</span>
+            </div>
+          )}
+          {orderedStories.map((story) => (
+            <StoryBubble
+              key={story._id}
+              story={story}
+              label={story.owner?.username}
+              onClick={openStory}
+            />
+          ))}
+        </div>
+      )}
+      <StoryViewer story={activeStory} open={viewerOpen} onOpenChange={setViewerOpen} />
+    </div>
+  )
+}
 
-export default StoriesBar;
+export default StoriesBar

--- a/frontend/src/components/SuggestedUsers.jsx
+++ b/frontend/src/components/SuggestedUsers.jsx
@@ -7,36 +7,36 @@ const SuggestedUsers = () => {
   const { suggestedUsers } = useSelector(store => store.auth)
   if (!suggestedUsers?.length) {
     return (
-      <div className='rounded-2xl border border-slate-800/60 bg-slate-950/40 p-5 text-sm text-slate-400'>
+      <div className='rounded-2xl border border-[rgba(0,0,0,0.05)] bg-white/70 p-5 text-sm text-[#6f6f6f] shadow-[0_14px_36px_-34px_rgba(200,169,241,0.6)]'>
         We are preparing fresh creators for you to follow. Check back soon!
       </div>
     )
   }
 
   return (
-    <div className='rounded-2xl border border-slate-800/60 bg-slate-950/40 p-5'>
-      <div className='flex items-center justify-between text-xs uppercase tracking-wide text-slate-500'>
-        <span className='font-semibold text-slate-300'>Suggested for you</span>
-        <button className='text-sky-300 transition hover:text-sky-200'>See all</button>
+    <div className='rounded-2xl border border-[rgba(0,0,0,0.05)] bg-white/75 p-5 shadow-[0_24px_50px_-42px_rgba(200,169,241,0.65)]'>
+      <div className='flex items-center justify-between text-xs uppercase tracking-wide text-[#8c8c8c]'>
+        <span className='font-semibold text-[#4a4a4a]'>Suggested for you</span>
+        <button className='text-[#c8a9f1] transition hover:text-[#b897e9]'>See all</button>
       </div>
       <div className='mt-5 flex flex-col gap-4'>
         {suggestedUsers.map((user) => (
-          <div key={user._id} className='flex items-center justify-between gap-3 rounded-xl border border-slate-800/60 bg-slate-900/60 px-4 py-3'>
+          <div key={user._id} className='flex items-center justify-between gap-3 rounded-xl border border-[rgba(0,0,0,0.05)] bg-white/80 px-4 py-3 shadow-[0_12px_28px_-36px_rgba(0,0,0,0.45)]'>
             <div className='flex items-center gap-3'>
-              <Link to={`/profile/${user?._id}`} className='rounded-2xl bg-sky-500/20 p-[2px]'>
-                <Avatar className='h-10 w-10 border border-slate-900'>
+              <Link to={`/profile/${user?._id}`} className='rounded-2xl bg-gradient-to-br from-[#c8a9f1]/30 via-[#e8d6c6]/30 to-[#f8c8a3]/30 p-[2px]'>
+                <Avatar className='h-10 w-10 border border-[rgba(0,0,0,0.05)] bg-white'>
                   <AvatarImage src={user?.profilePicture} alt='post_image' />
                   <AvatarFallback>CN</AvatarFallback>
                 </Avatar>
               </Link>
               <div className='flex flex-col'>
-                <h1 className='text-sm font-semibold text-slate-100'>
+                <h1 className='text-sm font-semibold text-[#333333]'>
                   <Link to={`/profile/${user?._id}`}>{user?.username}</Link>
                 </h1>
-                <span className='text-xs text-slate-400'>{user?.bio || 'New to NovaSphere'}</span>
+                <span className='text-xs text-[#8c8c8c]'>{user?.bio || 'New to NovaSphere'}</span>
               </div>
             </div>
-            <Button size='sm' className='rounded-full bg-gradient-to-r from-sky-500 to-emerald-400 text-slate-950 hover:from-sky-400 hover:to-emerald-300'>Follow</Button>
+            <Button size='sm' className='rounded-full px-5'>Follow</Button>
           </div>
         ))}
       </div>

--- a/frontend/src/components/SuggestedUsers.jsx
+++ b/frontend/src/components/SuggestedUsers.jsx
@@ -7,6 +7,14 @@ import { Button } from './ui/button'
 const SuggestedUsers = () => {
   const { suggestedUsers, user: authUser } = useSelector(store => store.auth)
 
+  const normaliseToArray = (value) => {
+    if (!value) return []
+    if (Array.isArray(value)) return value
+    if (value instanceof Set) return Array.from(value)
+    if (typeof value === 'object') return Object.values(value)
+    return []
+  }
+
   const filteredSuggestions = useMemo(() => {
     const exclusionSet = new Set()
 
@@ -14,19 +22,19 @@ const SuggestedUsers = () => {
       exclusionSet.add(authUser._id.toString())
     }
 
-    (authUser?.following || []).forEach(id => {
+    normaliseToArray(authUser?.following).forEach(id => {
       if (id) {
         exclusionSet.add(id.toString())
       }
     })
 
-    (authUser?.sentFollowRequests || []).forEach(id => {
+    normaliseToArray(authUser?.sentFollowRequests).forEach(id => {
       if (id) {
         exclusionSet.add(id.toString())
       }
     })
 
-    return (suggestedUsers || []).filter(candidate => {
+    return normaliseToArray(suggestedUsers).filter(candidate => {
       const candidateId = candidate?._id?.toString?.() ?? candidate?._id
       if (!candidateId) return false
       return !exclusionSet.has(candidateId)

--- a/frontend/src/components/SuggestedUsers.jsx
+++ b/frontend/src/components/SuggestedUsers.jsx
@@ -1,13 +1,41 @@
+import { useMemo } from 'react'
 import { useSelector } from 'react-redux'
 import { Link } from 'react-router-dom'
 import { Avatar, AvatarFallback, AvatarImage } from './ui/avatar'
 import { Button } from './ui/button'
 
 const SuggestedUsers = () => {
-  const { suggestedUsers } = useSelector(store => store.auth)
-  if (!suggestedUsers?.length) {
+  const { suggestedUsers, user: authUser } = useSelector(store => store.auth)
+
+  const filteredSuggestions = useMemo(() => {
+    const exclusionSet = new Set()
+
+    if (authUser?._id) {
+      exclusionSet.add(authUser._id.toString())
+    }
+
+    (authUser?.following || []).forEach(id => {
+      if (id) {
+        exclusionSet.add(id.toString())
+      }
+    })
+
+    (authUser?.sentFollowRequests || []).forEach(id => {
+      if (id) {
+        exclusionSet.add(id.toString())
+      }
+    })
+
+    return (suggestedUsers || []).filter(candidate => {
+      const candidateId = candidate?._id?.toString?.() ?? candidate?._id
+      if (!candidateId) return false
+      return !exclusionSet.has(candidateId)
+    })
+  }, [authUser?._id, authUser?.following, authUser?.sentFollowRequests, suggestedUsers])
+
+  if (!filteredSuggestions.length) {
     return (
-      <div className='rounded-2xl border border-[rgba(0,0,0,0.05)] bg-white/70 p-5 text-sm text-[#6f6f6f] shadow-[0_14px_36px_-34px_rgba(200,169,241,0.6)]'>
+      <div className='rounded-2xl border border-[rgba(0,0,0,0.05)] bg-white/70 p-5 text-sm text-[var(--color-text-muted)] shadow-[0_14px_36px_-34px_rgba(200,169,241,0.6)]'>
         We are preparing fresh creators for you to follow. Check back soon!
       </div>
     )
@@ -15,12 +43,12 @@ const SuggestedUsers = () => {
 
   return (
     <div className='rounded-2xl border border-[rgba(0,0,0,0.05)] bg-white/75 p-5 shadow-[0_24px_50px_-42px_rgba(200,169,241,0.65)]'>
-      <div className='flex items-center justify-between text-xs uppercase tracking-wide text-[#8c8c8c]'>
-        <span className='font-semibold text-[#4a4a4a]'>Suggested for you</span>
+      <div className='flex items-center justify-between text-xs uppercase tracking-wide text-[#5a5a5a]'>
+        <span className='font-semibold text-[var(--color-text)]'>Suggested for you</span>
         <button className='text-[#c8a9f1] transition hover:text-[#b897e9]'>See all</button>
       </div>
       <div className='mt-5 flex flex-col gap-4'>
-        {suggestedUsers.map((user) => (
+        {filteredSuggestions.map((user) => (
           <div key={user._id} className='flex items-center justify-between gap-3 rounded-xl border border-[rgba(0,0,0,0.05)] bg-white/80 px-4 py-3 shadow-[0_12px_28px_-36px_rgba(0,0,0,0.45)]'>
             <div className='flex items-center gap-3'>
               <Link to={`/profile/${user?._id}`} className='rounded-2xl bg-gradient-to-br from-[#c8a9f1]/30 via-[#e8d6c6]/30 to-[#f8c8a3]/30 p-[2px]'>
@@ -30,10 +58,10 @@ const SuggestedUsers = () => {
                 </Avatar>
               </Link>
               <div className='flex flex-col'>
-                <h1 className='text-sm font-semibold text-[#333333]'>
+                <h1 className='text-sm font-semibold text-[var(--color-text)]'>
                   <Link to={`/profile/${user?._id}`}>{user?.username}</Link>
                 </h1>
-                <span className='text-xs text-[#8c8c8c]'>{user?.bio || 'New to NovaSphere'}</span>
+                <span className='text-xs text-[#5f5f5f]'>{user?.bio || "New to Let&apos;s Talk"}</span>
               </div>
             </div>
             <Button size='sm' className='rounded-full px-5'>Follow</Button>

--- a/frontend/src/components/SuggestedUsers.jsx
+++ b/frontend/src/components/SuggestedUsers.jsx
@@ -1,40 +1,47 @@
-import React from 'react'
 import { useSelector } from 'react-redux'
-import { Link } from 'react-router-dom';
-import { Avatar, AvatarFallback, AvatarImage } from './ui/avatar';
+import { Link } from 'react-router-dom'
+import { Avatar, AvatarFallback, AvatarImage } from './ui/avatar'
+import { Button } from './ui/button'
 
 const SuggestedUsers = () => {
-    const { suggestedUsers } = useSelector(store => store.auth);
+  const { suggestedUsers } = useSelector(store => store.auth)
+  if (!suggestedUsers?.length) {
     return (
-        <div className='my-10'>
-            <div className='flex items-center justify-between text-sm'>
-                <h1 className='font-semibold text-gray-600'>Suggested for you</h1>
-                <span className='font-medium cursor-pointer'>See All</span>
-            </div>
-            {
-                suggestedUsers.map((user) => {
-                    return (
-                        <div key={user._id} className='flex items-center justify-between my-5'>
-                            <div className='flex items-center gap-2'>
-                                <Link to={`/profile/${user?._id}`}>
-                                    <Avatar>
-                                        <AvatarImage src={user?.profilePicture} alt="post_image" />
-                                        <AvatarFallback>CN</AvatarFallback>
-                                    </Avatar>
-                                </Link>
-                                <div>
-                                    <h1 className='font-semibold text-sm'><Link to={`/profile/${user?._id}`}>{user?.username}</Link></h1>
-                                    <span className='text-gray-600 text-sm'>{user?.bio || 'Bio here...'}</span>
-                                </div>
-                            </div>
-                            <span className='text-[#3BADF8] text-xs font-bold cursor-pointer hover:text-[#3495d6]'>Follow</span>
-                        </div>
-                    )
-                })
-            }
-
-        </div>
+      <div className='rounded-2xl border border-slate-800/60 bg-slate-950/40 p-5 text-sm text-slate-400'>
+        We are preparing fresh creators for you to follow. Check back soon!
+      </div>
     )
+  }
+
+  return (
+    <div className='rounded-2xl border border-slate-800/60 bg-slate-950/40 p-5'>
+      <div className='flex items-center justify-between text-xs uppercase tracking-wide text-slate-500'>
+        <span className='font-semibold text-slate-300'>Suggested for you</span>
+        <button className='text-sky-300 transition hover:text-sky-200'>See all</button>
+      </div>
+      <div className='mt-5 flex flex-col gap-4'>
+        {suggestedUsers.map((user) => (
+          <div key={user._id} className='flex items-center justify-between gap-3 rounded-xl border border-slate-800/60 bg-slate-900/60 px-4 py-3'>
+            <div className='flex items-center gap-3'>
+              <Link to={`/profile/${user?._id}`} className='rounded-2xl bg-sky-500/20 p-[2px]'>
+                <Avatar className='h-10 w-10 border border-slate-900'>
+                  <AvatarImage src={user?.profilePicture} alt='post_image' />
+                  <AvatarFallback>CN</AvatarFallback>
+                </Avatar>
+              </Link>
+              <div className='flex flex-col'>
+                <h1 className='text-sm font-semibold text-slate-100'>
+                  <Link to={`/profile/${user?._id}`}>{user?.username}</Link>
+                </h1>
+                <span className='text-xs text-slate-400'>{user?.bio || 'New to NovaSphere'}</span>
+              </div>
+            </div>
+            <Button size='sm' className='rounded-full bg-gradient-to-r from-sky-500 to-emerald-400 text-slate-950 hover:from-sky-400 hover:to-emerald-300'>Follow</Button>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
 }
 
 export default SuggestedUsers

--- a/frontend/src/components/SuggestedUsers.jsx
+++ b/frontend/src/components/SuggestedUsers.jsx
@@ -1,11 +1,18 @@
-import { useMemo } from 'react'
-import { useSelector } from 'react-redux'
+import { useMemo, useState } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
 import { Link } from 'react-router-dom'
 import { Avatar, AvatarFallback, AvatarImage } from './ui/avatar'
 import { Button } from './ui/button'
+import axios from 'axios'
+import { toast } from 'sonner'
+import { setAuthUser, setSuggestedUsers } from '@/redux/authSlice'
+import { computeUpdatedAuthUserAfterFollowAction, normaliseIdArray } from '@/lib/relationships'
 
 const SuggestedUsers = () => {
+  const dispatch = useDispatch()
   const { suggestedUsers, user: authUser } = useSelector(store => store.auth)
+  const [processingIds, setProcessingIds] = useState(() => new Set())
+  const [dismissedIds, setDismissedIds] = useState(() => new Set())
 
   const normaliseToArray = (value) => {
     if (!value) return []
@@ -34,12 +41,77 @@ const SuggestedUsers = () => {
       }
     })
 
+    const idsToSkip = new Set(dismissedIds)
+
     return normaliseToArray(suggestedUsers).filter(candidate => {
       const candidateId = candidate?._id?.toString?.() ?? candidate?._id
       if (!candidateId) return false
-      return !exclusionSet.has(candidateId)
+      const candidateIdString = candidateId.toString()
+      if (idsToSkip.has(candidateIdString)) return false
+      return !exclusionSet.has(candidateIdString)
     })
-  }, [authUser?._id, authUser?.following, authUser?.sentFollowRequests, suggestedUsers])
+  }, [authUser?._id, authUser?.following, authUser?.sentFollowRequests, dismissedIds, suggestedUsers])
+
+  const viewerFollowings = useMemo(() => new Set(normaliseIdArray(authUser?.following)), [authUser?.following])
+  const viewerPendingRequests = useMemo(() => new Set(normaliseIdArray(authUser?.sentFollowRequests)), [authUser?.sentFollowRequests])
+
+  const updateAuthUserRelationships = (status, targetId) => {
+    if (!authUser) return
+    const updatedAuthUser = computeUpdatedAuthUserAfterFollowAction(authUser, status, targetId)
+    dispatch(setAuthUser(updatedAuthUser))
+  }
+
+  const handleFollowUser = async (candidate) => {
+    const targetId = candidate?._id
+    if (!targetId || !authUser?._id) return
+
+    const idString = targetId.toString()
+    setProcessingIds(prev => {
+      const next = new Set(prev)
+      next.add(idString)
+      return next
+    })
+
+    try {
+      const res = await axios.post(`https://let-s-talk-lq7h.onrender.com/api/v1/user/followorunfollow/${idString}`, {}, { withCredentials: true })
+      const status = res?.data?.status
+      if (res?.data?.success && status) {
+        updateAuthUserRelationships(status, idString)
+
+        if (status === 'followed' || status === 'requested') {
+          dispatch(setSuggestedUsers(normaliseToArray(suggestedUsers).filter(user => {
+            const candidateId = user?._id?.toString?.() ?? user?._id
+            return candidateId?.toString() !== idString
+          })))
+
+          setDismissedIds(prev => {
+            const next = new Set(prev)
+            next.add(idString)
+            return next
+          })
+        }
+
+        if (status === 'requested') {
+          toast.success('Follow request sent')
+        } else if (status === 'request_cancelled') {
+          toast.success('Follow request cancelled')
+        } else if (status === 'followed') {
+          toast.success(`You are now following ${candidate?.username || 'this account'}`)
+        } else if (status === 'unfollowed') {
+          toast.success(`Unfollowed ${candidate?.username || 'this account'}`)
+        }
+      }
+    } catch (error) {
+      console.log(error)
+      toast.error(error?.response?.data?.message || 'Unable to update follow status')
+    } finally {
+      setProcessingIds(prev => {
+        const next = new Set(prev)
+        next.delete(idString)
+        return next
+      })
+    }
+  }
 
   if (!filteredSuggestions.length) {
     return (
@@ -56,25 +128,41 @@ const SuggestedUsers = () => {
         <button className='text-[#c8a9f1] transition hover:text-[#b897e9]'>See all</button>
       </div>
       <div className='mt-5 flex flex-col gap-4'>
-        {filteredSuggestions.map((user) => (
-          <div key={user._id} className='flex items-center justify-between gap-3 rounded-xl border border-[rgba(0,0,0,0.05)] bg-white/80 px-4 py-3 shadow-[0_12px_28px_-36px_rgba(0,0,0,0.45)]'>
-            <div className='flex items-center gap-3'>
-              <Link to={`/profile/${user?._id}`} className='rounded-2xl bg-gradient-to-br from-[#c8a9f1]/30 via-[#e8d6c6]/30 to-[#f8c8a3]/30 p-[2px]'>
-                <Avatar className='h-10 w-10 border border-[rgba(0,0,0,0.05)] bg-white'>
-                  <AvatarImage src={user?.profilePicture} alt='post_image' />
-                  <AvatarFallback>CN</AvatarFallback>
-                </Avatar>
-              </Link>
-              <div className='flex flex-col'>
-                <h1 className='text-sm font-semibold text-[var(--color-text)]'>
-                  <Link to={`/profile/${user?._id}`}>{user?.username}</Link>
-                </h1>
-                <span className='text-xs text-[#5f5f5f]'>{user?.bio || "New to Let&apos;s Talk"}</span>
+        {filteredSuggestions.map((user) => {
+          const idString = user?._id?.toString?.() ?? user?._id
+          const isProcessing = processingIds.has(idString)
+          const hasPendingRequest = viewerPendingRequests.has(idString)
+          const isFollowing = viewerFollowings.has(idString)
+          const buttonLabel = isFollowing ? 'Following' : hasPendingRequest ? 'Requested' : 'Follow'
+
+          return (
+            <div key={user._id} className='flex items-center justify-between gap-3 rounded-xl border border-[rgba(0,0,0,0.05)] bg-white/80 px-4 py-3 shadow-[0_12px_28px_-36px_rgba(0,0,0,0.45)]'>
+              <div className='flex items-center gap-3'>
+                <Link to={`/profile/${user?._id}`} className='rounded-2xl bg-gradient-to-br from-[#c8a9f1]/30 via-[#e8d6c6]/30 to-[#f8c8a3]/30 p-[2px]'>
+                  <Avatar className='h-10 w-10 border border-[rgba(0,0,0,0.05)] bg-white'>
+                    <AvatarImage src={user?.profilePicture} alt='post_image' />
+                    <AvatarFallback>CN</AvatarFallback>
+                  </Avatar>
+                </Link>
+                <div className='flex flex-col'>
+                  <h1 className='text-sm font-semibold text-[var(--color-text)]'>
+                    <Link to={`/profile/${user?._id}`}>{user?.username}</Link>
+                  </h1>
+                  <span className='text-xs text-[#5f5f5f]'>{user?.bio || "New to Let&apos;s Talk"}</span>
+                </div>
               </div>
+              <Button
+                size='sm'
+                className='rounded-full px-5'
+                disabled={isProcessing || isFollowing}
+                variant={hasPendingRequest ? 'secondary' : 'default'}
+                onClick={() => handleFollowUser(user)}
+              >
+                {isProcessing ? 'Please wait…' : buttonLabel}
+              </Button>
             </div>
-            <Button size='sm' className='rounded-full px-5'>Follow</Button>
-          </div>
-        ))}
+          )
+        })}
       </div>
     </div>
   )

--- a/frontend/src/components/ui/badge.jsx
+++ b/frontend/src/components/ui/badge.jsx
@@ -4,17 +4,14 @@ import { cva } from "class-variance-authority";
 import { cn } from "@/lib/utils"
 
 const badgeVariants = cva(
-  "inline-flex items-center rounded-full border border-slate-200 px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-slate-950 focus:ring-offset-2 dark:border-slate-800 dark:focus:ring-slate-300",
+  "inline-flex items-center rounded-full border border-[rgba(0,0,0,0.06)] px-2.5 py-0.5 text-xs font-semibold text-[#4a4a4a] transition-colors focus:outline-none focus:ring-2 focus:ring-[#c8a9f1] focus:ring-offset-2",
   {
     variants: {
       variant: {
-        default:
-          "border-transparent bg-slate-900 text-slate-50 hover:bg-slate-900/80 dark:bg-slate-50 dark:text-slate-900 dark:hover:bg-slate-50/80",
-        secondary:
-          "border-transparent bg-slate-100 text-slate-900 hover:bg-slate-100/80 dark:bg-slate-800 dark:text-slate-50 dark:hover:bg-slate-800/80",
-        destructive:
-          "border-transparent bg-red-500 text-slate-50 hover:bg-red-500/80 dark:bg-red-900 dark:text-slate-50 dark:hover:bg-red-900/80",
-        outline: "text-slate-950 dark:text-slate-50",
+        default: "border-transparent bg-[#f0e9ff] text-[#4a4a4a]",
+        secondary: "border-transparent bg-[#e8d6c6] text-[#4a4a4a]",
+        destructive: "border-transparent bg-[#f5d4d4] text-[#9d4c4c]",
+        outline: "text-[#4a4a4a]",
       },
     },
     defaultVariants: {
@@ -28,7 +25,7 @@ function Badge({
   variant,
   ...props
 }) {
-  return (<div className={cn(badgeVariants({ variant }), className)} {...props} />);
+  return <div className={cn(badgeVariants({ variant }), className)} {...props} />;
 }
 
 export { Badge, badgeVariants }

--- a/frontend/src/components/ui/button.jsx
+++ b/frontend/src/components/ui/button.jsx
@@ -5,19 +5,18 @@ import { cva } from "class-variance-authority";
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 dark:ring-offset-slate-950 dark:focus-visible:ring-slate-300",
+  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#c8a9f1] focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
   {
     variants: {
       variant: {
-        default: "bg-slate-900 text-slate-50 hover:bg-slate-900/90 dark:bg-slate-50 dark:text-slate-900 dark:hover:bg-slate-50/90",
-        destructive:
-          "bg-red-500 text-slate-50 hover:bg-red-500/90 dark:bg-red-900 dark:text-slate-50 dark:hover:bg-red-900/90",
+        default:
+          "bg-gradient-to-r from-[#c8a9f1] to-[#f8c8a3] text-[#333333] shadow-[0_12px_30px_-18px_rgba(200,169,241,0.8)] hover:from-[#b897e9] hover:to-[#f6b98d]",
+        destructive: "bg-red-500 text-white hover:bg-red-500/90",
         outline:
-          "border border-slate-200 bg-white hover:bg-slate-100 hover:text-slate-900 dark:border-slate-800 dark:bg-slate-950 dark:hover:bg-slate-800 dark:hover:text-slate-50",
-        secondary:
-          "bg-slate-100 text-slate-900 hover:bg-slate-100/80 dark:bg-slate-800 dark:text-slate-50 dark:hover:bg-slate-800/80",
-        ghost: "hover:bg-slate-100 hover:text-slate-900 dark:hover:bg-slate-800 dark:hover:text-slate-50",
-        link: "text-slate-900 underline-offset-4 hover:underline dark:text-slate-50",
+          "border border-[rgba(0,0,0,0.08)] bg-white text-[#4a4a4a] hover:border-[rgba(0,0,0,0.15)] hover:bg-[#fdf9ff]",
+        secondary: "bg-[#e8d6c6] text-[#4a4a4a] hover:bg-[#ddc4b0]",
+        ghost: "hover:bg-[#f0e9ff] hover:text-[#4a4a4a]",
+        link: "text-[#4a4a4a] underline-offset-4 hover:text-[#c8a9f1]",
       },
       size: {
         default: "h-10 px-4 py-2",
@@ -36,10 +35,11 @@ const buttonVariants = cva(
 const Button = React.forwardRef(({ className, variant, size, asChild = false, ...props }, ref) => {
   const Comp = asChild ? Slot : "button"
   return (
-    (<Comp
+    <Comp
       className={cn(buttonVariants({ variant, size, className }))}
       ref={ref}
-      {...props} />)
+      {...props}
+    />
   );
 })
 Button.displayName = "Button"

--- a/frontend/src/components/ui/button.jsx
+++ b/frontend/src/components/ui/button.jsx
@@ -5,24 +5,24 @@ import { cva } from "class-variance-authority";
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#c8a9f1] focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-semibold tracking-wide ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#c8a9f1] focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
   {
     variants: {
       variant: {
         default:
-          "bg-gradient-to-r from-[#c8a9f1] to-[#f8c8a3] text-[#333333] shadow-[0_12px_30px_-18px_rgba(200,169,241,0.8)] hover:from-[#b897e9] hover:to-[#f6b98d]",
+          "bg-[var(--color-primary-solid)] text-[#333333] shadow-[0_8px_16px_rgba(0,0,0,0.08)] hover:bg-[#c0a4eb]",
         destructive: "bg-red-500 text-white hover:bg-red-500/90",
         outline:
-          "border border-[rgba(0,0,0,0.08)] bg-white text-[#4a4a4a] hover:border-[rgba(0,0,0,0.15)] hover:bg-[#fdf9ff]",
-        secondary: "bg-[#e8d6c6] text-[#4a4a4a] hover:bg-[#ddc4b0]",
-        ghost: "hover:bg-[#f0e9ff] hover:text-[#4a4a4a]",
-        link: "text-[#4a4a4a] underline-offset-4 hover:text-[#c8a9f1]",
+          "border border-[var(--color-outline)] bg-[var(--color-surface)] text-[var(--color-text)] hover:bg-[var(--color-surface-muted)]",
+        secondary: "bg-[var(--color-accent-soft)] text-[var(--color-text)] hover:bg-[#d9c4ad]",
+        ghost: "text-[var(--color-text-muted)] hover:bg-[var(--color-surface-muted)] hover:text-[var(--color-text)]",
+        link: "text-[var(--color-text)] underline-offset-4 hover:text-[var(--color-primary-start)]",
       },
       size: {
-        default: "h-10 px-4 py-2",
-        sm: "h-9 rounded-md px-3",
-        lg: "h-11 rounded-md px-8",
-        icon: "h-10 w-10",
+        default: "h-11 px-5",
+        sm: "h-9 rounded-md px-4",
+        lg: "h-12 rounded-md px-10",
+        icon: "h-11 w-11",
       },
     },
     defaultVariants: {

--- a/frontend/src/components/ui/dialog.jsx
+++ b/frontend/src/components/ui/dialog.jsx
@@ -16,7 +16,7 @@ const DialogOverlay = React.forwardRef(({ className, ...props }, ref) => (
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-50 bg-[#f6f6f6]/60 backdrop-blur-[2px] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
     )}
     {...props} />
@@ -29,7 +29,7 @@ const DialogContent = React.forwardRef(({ className, children, ...props }, ref) 
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border border-slate-200 bg-white p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg dark:border-slate-800 dark:bg-slate-950",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 rounded-3xl border border-[rgba(0,0,0,0.06)] bg-white/95 p-6 text-[#333333] shadow-[0_28px_70px_-48px_rgba(51,51,51,0.55)] duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]",
         className
       )}
       {...props}>
@@ -75,7 +75,7 @@ DialogTitle.displayName = DialogPrimitive.Title.displayName
 const DialogDescription = React.forwardRef(({ className, ...props }, ref) => (
   <DialogPrimitive.Description
     ref={ref}
-    className={cn("text-sm text-slate-500 dark:text-slate-400", className)}
+    className={cn("text-sm text-[#6f6f6f]", className)}
     {...props} />
 ))
 DialogDescription.displayName = DialogPrimitive.Description.displayName

--- a/frontend/src/components/ui/input.jsx
+++ b/frontend/src/components/ui/input.jsx
@@ -4,14 +4,15 @@ import { cn } from "@/lib/utils"
 
 const Input = React.forwardRef(({ className, type, ...props }, ref) => {
   return (
-    (<input
+    <input
       type={type}
       className={cn(
-        "flex h-10 w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-sm ring-offset-white file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-slate-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-950 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-800 dark:bg-slate-950 dark:ring-offset-slate-950 dark:placeholder:text-slate-400 dark:focus-visible:ring-slate-300",
+        "flex h-10 w-full rounded-md border border-[rgba(0,0,0,0.08)] bg-white px-3 py-2 text-sm text-[#333333] ring-offset-white placeholder:text-[#b8b8b8] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#c8a9f1] focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
         className
       )}
       ref={ref}
-      {...props} />)
+      {...props}
+    />
   );
 })
 Input.displayName = "Input"

--- a/frontend/src/components/ui/input.jsx
+++ b/frontend/src/components/ui/input.jsx
@@ -7,7 +7,7 @@ const Input = React.forwardRef(({ className, type, ...props }, ref) => {
     <input
       type={type}
       className={cn(
-        "flex h-10 w-full rounded-md border border-[rgba(0,0,0,0.08)] bg-white px-3 py-2 text-sm text-[#333333] ring-offset-white placeholder:text-[#b8b8b8] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#c8a9f1] focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+        "flex h-11 w-full rounded-md border border-[var(--color-outline)] bg-[var(--color-surface)] px-4 text-sm text-[var(--color-text)] ring-offset-white placeholder:text-[#a0a0a0] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#c8a9f1] focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
         className
       )}
       ref={ref}

--- a/frontend/src/components/ui/popover.jsx
+++ b/frontend/src/components/ui/popover.jsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import * as PopoverPrimitive from "@radix-ui/react-popover"
+import * as PopoverPrimitive from "@radix-ui/react-popover";
 
 import { cn } from "@/lib/utils"
 
@@ -7,19 +7,20 @@ const Popover = PopoverPrimitive.Root
 
 const PopoverTrigger = PopoverPrimitive.Trigger
 
+const PopoverAnchor = PopoverPrimitive.Anchor
+
 const PopoverContent = React.forwardRef(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
-  <PopoverPrimitive.Portal>
-    <PopoverPrimitive.Content
-      ref={ref}
-      align={align}
-      sideOffset={sideOffset}
-      className={cn(
-        "z-50 w-72 rounded-md border border-slate-200 bg-white p-4 text-slate-950 shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 dark:border-slate-800 dark:bg-slate-950 dark:text-slate-50",
-        className
-      )}
-      {...props} />
-  </PopoverPrimitive.Portal>
+  <PopoverPrimitive.Content
+    ref={ref}
+    align={align}
+    sideOffset={sideOffset}
+    className={cn(
+      "z-50 w-72 rounded-md border border-[rgba(0,0,0,0.08)] bg-white p-4 text-[#4a4a4a] shadow-[0_24px_60px_-48px_rgba(51,51,51,0.45)] outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+      className
+    )}
+    {...props}
+  />
 ))
 PopoverContent.displayName = PopoverPrimitive.Content.displayName
 
-export { Popover, PopoverTrigger, PopoverContent }
+export { Popover, PopoverTrigger, PopoverContent, PopoverAnchor }

--- a/frontend/src/components/ui/select.jsx
+++ b/frontend/src/components/ui/select.jsx
@@ -1,5 +1,6 @@
 import * as React from "react"
-import * as SelectPrimitive from "@radix-ui/react-select"
+
+import * as SelectPrimitive from "@radix-ui/react-select";
 import { Check, ChevronDown, ChevronUp } from "lucide-react"
 
 import { cn } from "@/lib/utils"
@@ -14,13 +15,14 @@ const SelectTrigger = React.forwardRef(({ className, children, ...props }, ref) 
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex h-10 w-full items-center justify-between rounded-md border border-slate-200 bg-white px-3 py-2 text-sm ring-offset-white placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-950 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1 dark:border-slate-800 dark:bg-slate-950 dark:ring-offset-slate-950 dark:placeholder:text-slate-400 dark:focus:ring-slate-300",
+      "flex h-10 w-full items-center justify-between rounded-md border border-[rgba(0,0,0,0.08)] bg-white px-3 py-2 text-sm text-[#333333] ring-offset-white placeholder:text-[#b8b8b8] focus:outline-none focus:ring-2 focus:ring-[#c8a9f1] focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
       className
     )}
-    {...props}>
+    {...props}
+  >
     {children}
     <SelectPrimitive.Icon asChild>
-      <ChevronDown className="h-4 w-4 opacity-50" />
+      <ChevronDown className="h-4 w-4 text-[#b8b8b8]" />
     </SelectPrimitive.Icon>
   </SelectPrimitive.Trigger>
 ))
@@ -29,8 +31,9 @@ SelectTrigger.displayName = SelectPrimitive.Trigger.displayName
 const SelectScrollUpButton = React.forwardRef(({ className, ...props }, ref) => (
   <SelectPrimitive.ScrollUpButton
     ref={ref}
-    className={cn("flex cursor-default items-center justify-center py-1", className)}
-    {...props}>
+    className={cn("flex cursor-default items-center justify-center py-1 text-[#4a4a4a]", className)}
+    {...props}
+  >
     <ChevronUp className="h-4 w-4" />
   </SelectPrimitive.ScrollUpButton>
 ))
@@ -39,30 +42,35 @@ SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName
 const SelectScrollDownButton = React.forwardRef(({ className, ...props }, ref) => (
   <SelectPrimitive.ScrollDownButton
     ref={ref}
-    className={cn("flex cursor-default items-center justify-center py-1", className)}
-    {...props}>
+    className={cn("flex cursor-default items-center justify-center py-1 text-[#4a4a4a]", className)}
+    {...props}
+  >
     <ChevronDown className="h-4 w-4" />
   </SelectPrimitive.ScrollDownButton>
 ))
-SelectScrollDownButton.displayName =
-  SelectPrimitive.ScrollDownButton.displayName
+SelectScrollDownButton.displayName = SelectPrimitive.ScrollDownButton.displayName
 
 const SelectContent = React.forwardRef(({ className, children, position = "popper", ...props }, ref) => (
   <SelectPrimitive.Portal>
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        "relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border border-slate-200 bg-white text-slate-950 shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 dark:border-slate-800 dark:bg-slate-950 dark:text-slate-50",
+        "relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border border-[rgba(0,0,0,0.08)] bg-white text-[#333333] shadow-[0_20px_40px_-35px_rgba(51,51,51,0.35)] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         position === "popper" &&
           "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
         className
       )}
       position={position}
-      {...props}>
+      {...props}
+    >
       <SelectScrollUpButton />
       <SelectPrimitive.Viewport
-        className={cn("p-1", position === "popper" &&
-          "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]")}>
+        className={cn(
+          "p-1",
+          position === "popper" &&
+            "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]"
+        )}
+      >
         {children}
       </SelectPrimitive.Viewport>
       <SelectScrollDownButton />
@@ -74,8 +82,9 @@ SelectContent.displayName = SelectPrimitive.Content.displayName
 const SelectLabel = React.forwardRef(({ className, ...props }, ref) => (
   <SelectPrimitive.Label
     ref={ref}
-    className={cn("py-1.5 pl-8 pr-2 text-sm font-semibold", className)}
-    {...props} />
+    className={cn("px-2 py-1.5 text-sm font-semibold text-[#4a4a4a]", className)}
+    {...props}
+  />
 ))
 SelectLabel.displayName = SelectPrimitive.Label.displayName
 
@@ -83,16 +92,16 @@ const SelectItem = React.forwardRef(({ className, children, ...props }, ref) => 
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-slate-100 focus:text-slate-900 data-[disabled]:pointer-events-none data-[disabled]:opacity-50 dark:focus:bg-slate-800 dark:focus:text-slate-50",
+      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm text-[#4a4a4a] outline-none focus:bg-[#f0e9ff] focus:text-[#333333] data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className
     )}
-    {...props}>
+    {...props}
+  >
     <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
       <SelectPrimitive.ItemIndicator>
         <Check className="h-4 w-4" />
       </SelectPrimitive.ItemIndicator>
     </span>
-
     <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
   </SelectPrimitive.Item>
 ))
@@ -101,8 +110,9 @@ SelectItem.displayName = SelectPrimitive.Item.displayName
 const SelectSeparator = React.forwardRef(({ className, ...props }, ref) => (
   <SelectPrimitive.Separator
     ref={ref}
-    className={cn("-mx-1 my-1 h-px bg-slate-100 dark:bg-slate-800", className)}
-    {...props} />
+    className={cn("-mx-1 my-1 h-px bg-[rgba(0,0,0,0.08)]", className)}
+    {...props}
+  />
 ))
 SelectSeparator.displayName = SelectPrimitive.Separator.displayName
 

--- a/frontend/src/components/ui/sonner.jsx
+++ b/frontend/src/components/ui/sonner.jsx
@@ -7,21 +7,22 @@ const Toaster = ({
   const { theme = "system" } = useTheme()
 
   return (
-    (<Sonner
+    <Sonner
       theme={theme}
       className="toaster group"
       toastOptions={{
         classNames: {
           toast:
-            "group toast group-[.toaster]:bg-white group-[.toaster]:text-slate-950 group-[.toaster]:border-slate-200 group-[.toaster]:shadow-lg dark:group-[.toaster]:bg-slate-950 dark:group-[.toaster]:text-slate-50 dark:group-[.toaster]:border-slate-800",
-          description: "group-[.toast]:text-slate-500 dark:group-[.toast]:text-slate-400",
+            "group toast group-[.toaster]:bg-white group-[.toaster]:text-[#333333] group-[.toaster]:border-[rgba(0,0,0,0.08)] group-[.toaster]:shadow-[0_24px_60px_-48px_rgba(51,51,51,0.35)] dark:group-[.toaster]:bg-slate-950 dark:group-[.toaster]:text-slate-50 dark:group-[.toaster]:border-slate-800",
+          description: "group-[.toast]:text-[#6f6f6f] dark:group-[.toast]:text-slate-400",
           actionButton:
-            "group-[.toast]:bg-slate-900 group-[.toast]:text-slate-50 dark:group-[.toast]:bg-slate-50 dark:group-[.toast]:text-slate-900",
+            "group-[.toast]:bg-gradient-to-r from-[#c8a9f1] to-[#f8c8a3] group-[.toast]:text-[#333333] dark:group-[.toast]:bg-slate-50 dark:group-[.toast]:text-slate-900",
           cancelButton:
-            "group-[.toast]:bg-slate-100 group-[.toast]:text-slate-500 dark:group-[.toast]:bg-slate-800 dark:group-[.toast]:text-slate-400",
+            "group-[.toast]:bg-[#f0e9ff] group-[.toast]:text-[#4a4a4a] dark:group-[.toast]:bg-slate-800 dark:group-[.toast]:text-slate-400",
         },
       }}
-      {...props} />)
+      {...props}
+    />
   );
 }
 

--- a/frontend/src/components/ui/textarea.jsx
+++ b/frontend/src/components/ui/textarea.jsx
@@ -4,13 +4,14 @@ import { cn } from "@/lib/utils"
 
 const Textarea = React.forwardRef(({ className, ...props }, ref) => {
   return (
-    (<textarea
+    <textarea
       className={cn(
-        "flex min-h-[80px] w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-sm ring-offset-white placeholder:text-slate-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-950 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-800 dark:bg-slate-950 dark:ring-offset-slate-950 dark:placeholder:text-slate-400 dark:focus-visible:ring-slate-300",
+        "flex min-h-[80px] w-full rounded-md border border-[rgba(0,0,0,0.08)] bg-white px-3 py-2 text-sm text-[#333333] ring-offset-white placeholder:text-[#b8b8b8] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#c8a9f1] focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
         className
       )}
       ref={ref}
-      {...props} />)
+      {...props}
+    />
   );
 })
 Textarea.displayName = "Textarea"

--- a/frontend/src/hooks/useGetAllPost.jsx
+++ b/frontend/src/hooks/useGetAllPost.jsx
@@ -1,24 +1,25 @@
-import { setPosts } from "@/redux/postSlice";
-import axios from "axios";
-import { useEffect } from "react";
-import { useDispatch } from "react-redux";
-
+import { useEffect } from 'react'
+import axios from 'axios'
+import { useDispatch } from 'react-redux'
+import { setPosts } from '@/redux/postSlice'
 
 const useGetAllPost = () => {
-    const dispatch = useDispatch();
-    useEffect(() => {
-        const fetchAllPost = async () => {
-            try {
-                const res = await axios.get('https://let-s-talk-lq7h.onrender.com/api/v1/post/all', { withCredentials: true });
-                if (res.data.success) { 
-                    console.log(res.data.posts);
-                    dispatch(setPosts(res.data.posts));
-                }
-            } catch (error) {
-                console.log(error);
-            }
+  const dispatch = useDispatch()
+
+  useEffect(() => {
+    const fetchAllPost = async () => {
+      try {
+        const res = await axios.get('https://let-s-talk-lq7h.onrender.com/api/v1/post/all', { withCredentials: true })
+        if (res.data.success) {
+          dispatch(setPosts(res.data.posts))
         }
-        fetchAllPost();
-    }, []);
-};
-export default useGetAllPost;
+      } catch (error) {
+        console.log(error)
+      }
+    }
+
+    fetchAllPost()
+  }, [dispatch])
+}
+
+export default useGetAllPost

--- a/frontend/src/hooks/useGetSuggestedUsers.jsx
+++ b/frontend/src/hooks/useGetSuggestedUsers.jsx
@@ -1,23 +1,25 @@
-import { setSuggestedUsers } from "@/redux/authSlice";
-import axios from "axios";
-import { useEffect } from "react";
-import { useDispatch } from "react-redux";
-
+import { useEffect } from 'react'
+import axios from 'axios'
+import { useDispatch } from 'react-redux'
+import { setSuggestedUsers } from '@/redux/authSlice'
 
 const useGetSuggestedUsers = () => {
-    const dispatch = useDispatch();
-    useEffect(() => {
-        const fetchSuggestedUsers = async () => {
-            try {
-                const res = await axios.get('https://let-s-talk-lq7h.onrender.com/api/v1/user/suggested', { withCredentials: true });
-                if (res.data.success) { 
-                    dispatch(setSuggestedUsers(res.data.users));
-                }
-            } catch (error) {
-                console.log(error);
-            }
+  const dispatch = useDispatch()
+
+  useEffect(() => {
+    const fetchSuggestedUsers = async () => {
+      try {
+        const res = await axios.get('https://let-s-talk-lq7h.onrender.com/api/v1/user/suggested', { withCredentials: true })
+        if (res.data.success) {
+          dispatch(setSuggestedUsers(res.data.users))
         }
-        fetchSuggestedUsers();
-    }, []);
-};
-export default useGetSuggestedUsers;
+      } catch (error) {
+        console.log(error)
+      }
+    }
+
+    fetchSuggestedUsers()
+  }, [dispatch])
+}
+
+export default useGetSuggestedUsers

--- a/frontend/src/hooks/useGetUserProfile.jsx
+++ b/frontend/src/hooks/useGetUserProfile.jsx
@@ -1,28 +1,28 @@
-import { setUserProfile } from "@/redux/authSlice";
-import axios from "axios";
-import { useCallback, useEffect } from "react";
-import { useDispatch } from "react-redux";
-
+import { useCallback, useEffect } from 'react'
+import axios from 'axios'
+import { useDispatch } from 'react-redux'
+import { setUserProfile } from '@/redux/authSlice'
 
 const useGetUserProfile = (userId) => {
-    const dispatch = useDispatch();
-    // const [userProfile, setUserProfile] = useState(null);
-    const fetchUserProfile = useCallback(async () => {
-        if(!userId) return;
-        try {
-            const res = await axios.get(`https://let-s-talk-lq7h.onrender.com/api/v1/user/${userId}/profile`, { withCredentials: true });
-            if (res.data.success) {
-                dispatch(setUserProfile({ user: res.data.user, meta: res.data.meta }));
-            }
-        } catch (error) {
-            console.log(error);
-        }
-    }, [dispatch, userId]);
+  const dispatch = useDispatch()
 
-    useEffect(() => {
-        fetchUserProfile();
-    }, [fetchUserProfile]);
+  const fetchUserProfile = useCallback(async () => {
+    if (!userId) return
+    try {
+      const res = await axios.get(`https://let-s-talk-lq7h.onrender.com/api/v1/user/${userId}/profile`, { withCredentials: true })
+      if (res.data.success) {
+        dispatch(setUserProfile({ user: res.data.user, meta: res.data.meta }))
+      }
+    } catch (error) {
+      console.log(error)
+    }
+  }, [dispatch, userId])
 
-    return { refetch: fetchUserProfile };
-};
-export default useGetUserProfile;
+  useEffect(() => {
+    fetchUserProfile()
+  }, [fetchUserProfile])
+
+  return { refetch: fetchUserProfile }
+}
+
+export default useGetUserProfile

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -5,20 +5,23 @@
 :root {
   color-scheme: light;
   --color-background: #f6f6f6;
-  --color-surface: #ffffff;
-  --color-surface-subtle: #fbf7ff;
+  --color-surface: #fcfcfc;
+  --color-surface-raised: #ffffff;
+  --color-surface-muted: #f0edf6;
+  --color-outline: #d9d9d9;
   --color-primary-start: #c8a9f1;
   --color-primary-end: #f8c8a3;
+  --color-primary-solid: #cdb4f4;
   --color-accent: #d5b69d;
   --color-accent-soft: #e8d6c6;
   --color-text: #333333;
   --color-text-muted: #4a4a4a;
-  --color-divider: rgba(0, 0, 0, 0.05);
-  --color-shadow: rgba(0, 0, 0, 0.08);
+  --color-divider: rgba(0, 0, 0, 0.06);
+  --color-shadow: rgba(0, 0, 0, 0.04);
 }
 
 body {
-  background: var(--color-background);
+  background: linear-gradient(135deg, rgba(200, 169, 241, 0.08), rgba(248, 200, 163, 0.06)) var(--color-background);
   color: var(--color-text);
   font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
   min-height: 100vh;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,4 +1,35 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-  
+
+:root {
+  color-scheme: dark;
+}
+
+body {
+  @apply bg-slate-950 text-slate-100 antialiased;
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  min-height: 100vh;
+}
+
+a {
+  @apply text-sky-300 hover:text-sky-200 transition-colors;
+}
+
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+::-webkit-scrollbar-track {
+  background: rgba(15, 23, 42, 0.4);
+}
+
+::-webkit-scrollbar-thumb {
+  background: rgba(94, 234, 212, 0.35);
+  border-radius: 9999px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: rgba(94, 234, 212, 0.6);
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -14,8 +14,8 @@
   --color-primary-solid: #cdb4f4;
   --color-accent: #d5b69d;
   --color-accent-soft: #e8d6c6;
-  --color-text: #333333;
-  --color-text-muted: #4a4a4a;
+  --color-text: #1f1f1f;
+  --color-text-muted: #353535;
   --color-divider: rgba(0, 0, 0, 0.06);
   --color-shadow: rgba(0, 0, 0, 0.04);
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3,17 +3,35 @@
 @tailwind utilities;
 
 :root {
-  color-scheme: dark;
+  color-scheme: light;
+  --color-background: #f6f6f6;
+  --color-surface: #ffffff;
+  --color-surface-subtle: #fbf7ff;
+  --color-primary-start: #c8a9f1;
+  --color-primary-end: #f8c8a3;
+  --color-accent: #d5b69d;
+  --color-accent-soft: #e8d6c6;
+  --color-text: #333333;
+  --color-text-muted: #4a4a4a;
+  --color-divider: rgba(0, 0, 0, 0.05);
+  --color-shadow: rgba(0, 0, 0, 0.08);
 }
 
 body {
-  @apply bg-slate-950 text-slate-100 antialiased;
+  background: var(--color-background);
+  color: var(--color-text);
   font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
   min-height: 100vh;
+  -webkit-font-smoothing: antialiased;
 }
 
 a {
-  @apply text-sky-300 hover:text-sky-200 transition-colors;
+  color: var(--color-accent);
+  transition: color 0.2s ease;
+}
+
+a:hover {
+  color: var(--color-primary-start);
 }
 
 ::-webkit-scrollbar {
@@ -22,14 +40,14 @@ a {
 }
 
 ::-webkit-scrollbar-track {
-  background: rgba(15, 23, 42, 0.4);
+  background: rgba(0, 0, 0, 0.05);
 }
 
 ::-webkit-scrollbar-thumb {
-  background: rgba(94, 234, 212, 0.35);
+  background: rgba(197, 169, 226, 0.55);
   border-radius: 9999px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: rgba(94, 234, 212, 0.6);
+  background: rgba(213, 182, 157, 0.8);
 }

--- a/frontend/src/lib/relationships.js
+++ b/frontend/src/lib/relationships.js
@@ -1,0 +1,76 @@
+export const normaliseIdArray = (input) => {
+  if (!input) return []
+  if (Array.isArray(input)) {
+    return input
+      .map((value) => {
+        if (!value) return null
+        if (typeof value === 'string') return value
+        if (typeof value === 'number') return value.toString()
+        if (typeof value === 'object') {
+          if (value instanceof Map) {
+            return null
+          }
+          if ('_id' in value) {
+            const raw = value._id
+            if (typeof raw === 'string') return raw
+            if (raw && typeof raw.toString === 'function') return raw.toString()
+            return raw ?? null
+          }
+          if (value.id) {
+            const raw = value.id
+            if (typeof raw === 'string') return raw
+            if (raw && typeof raw.toString === 'function') return raw.toString()
+            return raw ?? null
+          }
+        }
+        if (value && typeof value.toString === 'function') {
+          return value.toString()
+        }
+        return null
+      })
+      .filter(Boolean)
+  }
+  if (typeof input === 'object') {
+    return normaliseIdArray(Object.values(input))
+  }
+  if (typeof input === 'string') return [input]
+  if (typeof input === 'number') return [input.toString()]
+  return []
+}
+
+export const computeUpdatedAuthUserAfterFollowAction = (authUser, status, targetId) => {
+  if (!authUser || !targetId) return authUser
+  const target = typeof targetId === 'string' ? targetId : targetId.toString()
+  const followingSet = new Set(normaliseIdArray(authUser.following))
+  const pendingSet = new Set(normaliseIdArray(authUser.sentFollowRequests))
+
+  switch (status) {
+    case 'followed': {
+      followingSet.add(target)
+      pendingSet.delete(target)
+      break
+    }
+    case 'unfollowed': {
+      followingSet.delete(target)
+      pendingSet.delete(target)
+      break
+    }
+    case 'requested': {
+      pendingSet.add(target)
+      followingSet.delete(target)
+      break
+    }
+    case 'request_cancelled': {
+      pendingSet.delete(target)
+      break
+    }
+    default:
+      break
+  }
+
+  return {
+    ...authUser,
+    following: Array.from(followingSet),
+    sentFollowRequests: Array.from(pendingSet),
+  }
+}

--- a/frontend/src/redux/rtnSlice.js
+++ b/frontend/src/redux/rtnSlice.js
@@ -15,9 +15,14 @@ const rtnSlice = createSlice({
     },
     clearNotifications: (state) => {
       state.likeNotification = []
+    },
+    dismissNotification: (state, action) => {
+      state.likeNotification = state.likeNotification.filter(
+        (notification) => (notification.postId || notification.userId) !== action.payload
+      )
     }
   }
 })
 
-export const { setLikeNotification, clearNotifications } = rtnSlice.actions
+export const { setLikeNotification, clearNotifications, dismissNotification } = rtnSlice.actions
 export default rtnSlice.reducer

--- a/frontend/src/redux/rtnSlice.js
+++ b/frontend/src/redux/rtnSlice.js
@@ -1,19 +1,23 @@
-import { createSlice } from "@reduxjs/toolkit";
+import { createSlice } from '@reduxjs/toolkit'
 
 const rtnSlice = createSlice({
-    name:'realTimeNotification',
-    initialState:{
-        likeNotification:[], // [1,2,3]
+  name: 'realTimeNotification',
+  initialState: {
+    likeNotification: []
+  },
+  reducers: {
+    setLikeNotification: (state, action) => {
+      if (action.payload.type === 'like') {
+        state.likeNotification.push(action.payload)
+      } else if (action.payload.type === 'dislike') {
+        state.likeNotification = state.likeNotification.filter((item) => item.userId !== action.payload.userId)
+      }
     },
-    reducers:{
-        setLikeNotification:(state,action)=>{
-            if(action.payload.type === 'like'){
-                state.likeNotification.push(action.payload);
-            }else if(action.payload.type === 'dislike'){
-                state.likeNotification = state.likeNotification.filter((item)=> item.userId !== action.payload.userId);
-            }
-        }
+    clearNotifications: (state) => {
+      state.likeNotification = []
     }
-});
-export const {setLikeNotification} = rtnSlice.actions;
-export default rtnSlice.reducer;
+  }
+})
+
+export const { setLikeNotification, clearNotifications } = rtnSlice.actions
+export default rtnSlice.reducer


### PR DESCRIPTION
## Summary
- refresh the global styling with a NovaSphere-inspired dark gradient theme and responsive shell
- redesign the left navigation, feed surface, and social cards to highlight stories, reels, posts, and suggestions with cohesive glassmorphism treatments
- update the right rail and quick actions so creation, notifications, and follow prompts are more discoverable across desktop and mobile

## Testing
- npm run lint *(fails: pre-existing prop-types and config errors throughout the project)*

------
https://chatgpt.com/codex/tasks/task_b_68e69c94cbe8832699cba4ac793252d9